### PR TITLE
Click data menu items to set as reference data

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -426,9 +426,9 @@ class Application(VuetifyTemplate, HubListener):
         else:
             raise NotImplementedError(f"cannot recognize new layer from {msg}")
 
-        wcs_only_refdata_icon = 'mdi-compass-outline'
+        wcs_only_refdata_icon = 'mdi-rotate-left'
         n_wcs_layers = (
-            len([icon.startswith('mdi') for icon in self.state.layer_icons])
+            len([icon.startswith('mdi-rotate-left') for icon in self.state.layer_icons])
             if is_wcs_only else 0
         )
         if layer_name not in self.state.layer_icons:
@@ -1960,6 +1960,9 @@ class Application(VuetifyTemplate, HubListener):
 
         wcs_only_layers = getattr(viewer.state, 'wcs_only_layers', [])
 
+        reference_data = getattr(viewer.state, 'reference_data', None)
+        reference_data_label = getattr(reference_data, 'label', None)
+
         return {
             'id': vid,
             'name': name or vid,
@@ -1970,7 +1973,7 @@ class Application(VuetifyTemplate, HubListener):
             'selected_data_items': {},  # noqa data_id: visibility state (visible, hidden, mixed), READ-ONLY
             'visible_layers': {},  # label: {color, label_suffix}, READ-ONLY
             'wcs_only_layers': wcs_only_layers,
-            'reference_data_label': getattr(viewer.state.reference_data, 'label', None),
+            'reference_data_label': reference_data_label,
             'canvas_angle': 0,  # canvas rotation clockwise rotation angle in deg
             'canvas_flip_horizontal': False,  # canvas rotation horizontal flip
             'config': self.config,  # give viewer access to app config/layout

--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -98,6 +98,7 @@
                   @data-item-unload="data_item_unload($event)"
                   @data-item-remove="data_item_remove($event)"
                   @call-viewer-method="call_viewer_method($event)"
+                  @change-reference-data="change_reference_data($event)"
                 ></g-viewer-tab>
               </gl-row>
             </golden-layout>

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -1,17 +1,23 @@
 <template>
   <span v-if="icon !== undefined">
+    <v-badge
+      dot
+      style="margin-right: 4px;"
+      color="accent"
+      :value="isRefData()">
     <v-icon v-if="String(icon).startsWith('mdi-')" size="16">
       {{icon}}
     </v-icon>
     <span v-else :class="prevent_invert_if_dark ? 'layer-viewer-icon' : 'invert-if-dark layer-viewer-icon'" :style="span_style+'; color: '+color+'; '+borderStyle">
       {{String(icon).toUpperCase()}}
     </span>
+  </v-badge>
   </span>
 </template>
 
 <script>
 module.exports = {
-  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark'],
+  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark', 'is_ref_data'],
   computed: {
     borderStyle() {
       if (this.$props.linewidth > 0) { 
@@ -19,6 +25,15 @@ module.exports = {
       }
       return ''
     },
+  },
+  methods: {
+    isRefData() {
+      if (this.$props.is_ref_data === undefined) {
+        return false
+      } else {
+        return this.$props.is_ref_data
+      }
+    }
   }
 };
 </script>

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -2,7 +2,7 @@
   <j-tooltip v-if="menuButtonAvailable()" tipid="viewer-toolbar-data">
     <v-menu attach offset-y :close-on-content-click="false" v-model="viewer.data_open">
       <template v-slot:activator="{ on, attrs }">
-        <v-btn 
+        <v-btn
           text 
           elevation="3" 
           v-bind="attrs" 
@@ -16,7 +16,6 @@
           <v-icon>mdi-format-list-bulleted-square</v-icon>
         </v-btn>
       </template>
-  
       <v-list style="max-height: 500px; width: 460px; padding-top: 0px" class="overflow-y-auto">
         <v-row key="title" style="padding-left: 25px; margin-right: 0px; background-color: #E3F2FD">
             <span style="overflow-wrap: anywhere; font-size: 12pt; padding-top: 6px; padding-left: 6px; font-weight: bold; color: black">
@@ -53,6 +52,7 @@
             @data-item-visibility="$emit('data-item-visibility', $event)"
             @data-item-unload="$emit('data-item-unload', $event)"
             @data-item-remove="$emit('data-item-remove', $event)"
+            @change-reference-data="$emit('change-reference-data', $event)"
           ></j-viewer-data-select-item>
         </v-row>
 
@@ -81,12 +81,11 @@
               :multi_select="multi_select"
               @data-item-visibility="$emit('data-item-visibility', $event)"
               @data-item-remove="$emit('data-item-remove', $event)"
+              @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select-item>
           </v-row>
         </div>
-
       </v-list>
-
     </v-menu>
   </j-tooltip>
 </template>
@@ -182,6 +181,15 @@ module.exports = {
       // toggle the visibility of the extra items in the menu
       this.showExtraItems = !this.showExtraItems
     },
+    isRefData() {
+      return this.$props.item.viewer.reference_data_label === this.$props.item.name
+    },
+    selectRefData() {
+      this.$emit('change-reference-data', {
+        id: this.$props.viewer.id,
+        item_id: this.$props.item.id
+      })
+    }
   },
   computed: {
     viewerTitleCase() {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -12,22 +12,26 @@
       </j-tooltip>
     </div>
 
-    <j-tooltip :tooltipcontent="'Click to set as reference data'" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
-      <span @click="selectRefData">
-      <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>
-      <div class="text-ellipsis-middle" style="font-weight: 500">
+    <j-tooltip
+      :tooltipcontent="isRefData() ? 'Reference data' : 'Click to set as reference data'"
+      span_style="font-size: 12pt; padding-top: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
+    <span
+      style="cursor: pointer;"
+      @click="selectRefData"
+    >
+      <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE" :is_ref_data="isRefData()"></j-layer-viewer-icon>
+
+      <div class="text-ellipsis-middle" style="font-weight: 500;">
         <span>
           {{itemNamePrefix}}
         </span>
         <span>
           {{itemNameExtension}}
         </span>
-        <span v-if="this.$props.viewer.config === 'imviz' && isRefData()">
-          {{"*"}}
-        </span>
       </div>
       </span>
     </j-tooltip>
+
 
     <div v-if="isSelected && isUnloadable" style="right: 2px">
       <j-tooltip tipid='viewer-data-disable'>
@@ -71,10 +75,12 @@ module.exports = {
       })
     },
     selectRefData() {
-      this.$emit('change-reference-data', {
-        id: this.$props.viewer.id,
-        item_id: this.$props.item.id
-      })
+      if (!this.isRefData()) {
+        this.$emit('change-reference-data', {
+          id: this.$props.viewer.id,
+          item_id: this.$props.item.id
+        })
+      }
     },
     isRefData() {
       return this.$props.viewer.reference_data_label == this.$props.item.name

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -13,7 +13,7 @@
     </div>
 
     <j-tooltip
-      :tooltipcontent="isRefData() && viewer.config === 'imviz' ? 'Current viewer orientation' : 'Set viewer orientation'"
+      :tooltipcontent=dataMenuTooltip
       span_style="font-size: 12pt; padding-top: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
     <span
       style="cursor: pointer;"
@@ -163,6 +163,15 @@ module.exports = {
         return 'black'
       } else {
         return 'gray'
+      }
+    },
+    dataMenuTooltip() {
+      if (this.$props.viewer.config === 'imviz' && this.isRefData()) {
+        return 'Current viewer orientation'
+      } else if (this.$props.viewer.config === 'imviz') {
+        return 'Set viewer orientation'
+      } else {
+        return null
       }
     }
   }

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -16,7 +16,7 @@
       :tooltipcontent=dataMenuTooltip
       span_style="font-size: 12pt; padding-top: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
     <span
-      style="cursor: pointer;"
+      :style="dataMenuTooltip !== null ? 'cursor: pointer;' : 'cursor: default;'"
       @click="selectRefData"
     >
       <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE" :is_ref_data="isRefData()"></j-layer-viewer-icon>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -11,19 +11,10 @@
         </v-btn>
       </j-tooltip>
     </div>
-    <div v-else>
-      <j-tooltip tipid="viewer-data-enable">
-        <v-btn v-if="this.$props.item.type !== 'wcs-only'"
-          icon
-          color="default"
-          @click="selectClicked">
-            <v-icon>mdi-plus</v-icon>
-        </v-btn>
-      </j-tooltip>
-    </div>
 
-    <j-tooltip :tooltipcontent="'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
-      <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>      
+    <j-tooltip :tooltipcontent="'Click to set as reference data'" span_style="font-size: 12pt; padding-top: 6px; padding-left: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
+      <span @click="selectRefData">
+      <j-layer-viewer-icon span_style="margin-left: 4px; margin-right: 2px" :icon="icon" color="#000000DE"></j-layer-viewer-icon>
       <div class="text-ellipsis-middle" style="font-weight: 500">
         <span>
           {{itemNamePrefix}}
@@ -31,7 +22,11 @@
         <span>
           {{itemNameExtension}}
         </span>
+        <span v-if="this.$props.viewer.config === 'imviz' && isRefData()">
+          {{"*"}}
+        </span>
       </div>
+      </span>
     </j-tooltip>
 
     <div v-if="isSelected && isUnloadable" style="right: 2px">
@@ -74,6 +69,15 @@ module.exports = {
         visible: prevVisibleState != 'visible' || (!this.multi_select && this.$props.item.type !== 'trace'),
         replace: !this.multi_select && this.$props.item.type !== 'trace'
       })
+    },
+    selectRefData() {
+      this.$emit('change-reference-data', {
+        id: this.$props.viewer.id,
+        item_id: this.$props.item.id
+      })
+    },
+    isRefData() {
+      return this.$props.viewer.reference_data_label == this.$props.item.name
     }
   },
   computed: {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -13,7 +13,7 @@
     </div>
 
     <j-tooltip
-      :tooltipcontent="isRefData() ? 'Reference data' : 'Click to set as reference data'"
+      :tooltipcontent="isRefData() && viewer.config === 'imviz' ? 'Current viewer orientation' : 'Set viewer orientation'"
       span_style="font-size: 12pt; padding-top: 6px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
     <span
       style="cursor: pointer;"

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -507,6 +507,10 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
 
     app._link_type = link_type
     app._wcs_use_affine = wcs_use_affine
+    viewer_ref = app._jdaviz_helper.default_viewer.reference
+    viewer_item = app._get_viewer_item(viewer_ref)
+
+    viewer_item['reference_data_label'] = refdata.label
 
     if link_plugin is not None:
         # Only broadcast after success.

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -151,29 +151,28 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         assert self.imviz.app.state.layer_icons["fits_wcs[DATA]"] == "a"
         assert self.viewer.state.reference_data.label == "fits_wcs[DATA]"
 
-        wcs_only_refdata_icon = "mdi-compass-outline"
-        wcs_only_not_refdata_icon = "mdi-compass-off-outline"
+        wcs_only_icon = "mdi-rotate-left"
 
         # Now we change the reference data.
         for i in (3, 4):
             data_label = self.imviz.app.data_collection[i].label
 
             # Icon before setting this WCS-only data as reference data.
-            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_not_refdata_icon
+            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_icon
 
             # Set it as reference data.
             self.imviz.app._change_reference_data(data_label)
             assert self.viewer.state.reference_data.label == data_label
 
             # Icon after setting it as reference data.
-            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_refdata_icon
+            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_icon
 
         # Change reference back to normal data.
         self.imviz.app._change_reference_data("fits_wcs[DATA]")
         assert self.viewer.state.reference_data.label == "fits_wcs[DATA]"
         for i in (3, 4):
             data_label = self.imviz.app.data_collection[i].label
-            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_not_refdata_icon
+            assert self.imviz.app.state.layer_icons[data_label] == wcs_only_icon
 
 
 def test_get_rotated_nddata_from_label_no_wcs(imviz_helper):

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -15,6 +15,7 @@
       @data-item-unload="$emit('data-item-unload', $event)"
       @data-item-remove="$emit('data-item-remove', $event)"
       @call-viewer-method="$emit('call-viewer-method', $event)"
+      @change-reference-data="$emit('change-reference-data', $event)"
     ></g-viewer-tab>
     <gl-component
       v-for="(viewer, index) in stack.viewers"
@@ -36,6 +37,7 @@
               @data-item-visibility="$emit('data-item-visibility', $event)"
               @data-item-unload="$emit('data-item-unload', $event)"
               @data-item-remove="$emit('data-item-remove', $event)"
+              @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select>
 
 


### PR DESCRIPTION
For https://github.com/spacetelescope/jdaviz/pull/2179.

For now, I'm exposing which item is selected as reference data by adding an asterisk to the item label. This is not a permanent solution, and here as a placeholder until we discuss with a long-term solution with @Jenneh.

https://github.com/bmorris3/jdaviz/assets/3497584/7b8b531c-a225-4064-ae3f-5c72ba361126
