### PR TITLE
Default WCS-only base layers in Imviz

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -511,17 +511,18 @@ class Application(VuetifyTemplate, HubListener):
 
         new_refdata = self.data_collection[new_refdata_label]
         viewer.state.reference_data = new_refdata
+
+        # Re-link
+        self._jdaviz_helper.link_data(link_type=self._link_type,
+                                      wcs_use_affine=self._wcs_use_affine,
+                                      error_on_fail=True)
+
         self.hub.broadcast(ChangeRefDataMessage(
             new_refdata,
             viewer,
             viewer_id=viewer_id,
             old=old_refdata,
             sender=self))
-
-        # Re-link
-        self._jdaviz_helper.link_data(link_type=self._link_type,
-                                      wcs_use_affine=self._wcs_use_affine,
-                                      error_on_fail=True)
 
         viewer.state.reset_limits()
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -505,17 +505,24 @@ class Application(VuetifyTemplate, HubListener):
         viewer = self._jdaviz_helper.default_viewer
         old_refdata = viewer.state.reference_data
 
+        # locate the central coordinate of old refdata in this viewer:
+        sky_cen = viewer._get_center_skycoord(old_refdata)
+
+        # estimate FOV in the viewer with old reference data:
+        fov_sky_init = viewer._get_fov(old_refdata)
+
         if new_refdata_label == old_refdata.label:
             # if there's no refdata change, don't do anything:
             return
 
+        # set the new reference data in the viewer:
         new_refdata = self.data_collection[new_refdata_label]
         viewer.state.reference_data = new_refdata
 
-        # Re-link
-        self._jdaviz_helper.link_data(link_type=self._link_type,
-                                      wcs_use_affine=self._wcs_use_affine,
-                                      error_on_fail=True)
+        # also update the viewer item's reference data label:
+        viewer_ref = self._jdaviz_helper.default_viewer.reference
+        viewer_item = self._get_viewer_item(viewer_ref)
+        viewer_item['reference_data_label'] = new_refdata.label
 
         self.hub.broadcast(ChangeRefDataMessage(
             new_refdata,
@@ -524,7 +531,17 @@ class Application(VuetifyTemplate, HubListener):
             old=old_refdata,
             sender=self))
 
-        viewer.state.reset_limits()
+        if all('_WCS_ONLY' in refdata.meta for refdata in [old_refdata, new_refdata]):
+            # adjust zoom to account for new refdata if both the
+            # old and new refdata are WCS-only layers
+            # (which also ensures zoom_level is already determined):
+            fov_sky_final = viewer._get_fov(new_refdata)
+            viewer.zoom(
+                float(fov_sky_final / fov_sky_init)
+            )
+
+        # re-center the viewer on previous location
+        viewer.center_on(sky_cen)
 
     def _link_new_data(self, reference_data=None, data_to_be_linked=None):
         """

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -17,7 +17,7 @@
     <template slot="selection" slot-scope="data">
       <div class="single-line">
         <span>
-          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
+          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true" :is_wcs_only="isWCSOnlyLayer()"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -36,7 +36,13 @@
 </template>
 <script>
 module.exports = {
-  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry']
+  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry'],
+  methods: {
+    isWCSOnlyLayer(item) {
+      const wcsOnly = Object.keys(this.$props.viewer.wcs_only_layers).includes(item.name)
+      return wcsOnly
+    },
+  }
 };
 </script>
 

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -75,7 +75,7 @@ module.exports = {
       })
     },
     selectRefData() {
-      if (!this.isRefData()) {
+      if (!this.isRefData() && this.$props.item.type === 'wcs-only') {
         this.$emit('change-reference-data', {
           id: this.$props.viewer.id,
           item_id: this.$props.item.id
@@ -168,7 +168,7 @@ module.exports = {
     dataMenuTooltip() {
       if (this.$props.viewer.config === 'imviz' && this.isRefData()) {
         return 'Current viewer orientation'
-      } else if (this.$props.viewer.config === 'imviz') {
+      } else if (this.$props.viewer.config === 'imviz' && this.$props.item.type === 'wcs-only') {
         return 'Set viewer orientation'
       } else {
         return null

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -4,6 +4,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
+import astropy.units as u
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from glue.core import BaseData
 from glue.core.link_helpers import LinkSame
@@ -11,8 +12,13 @@ from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink, NoAffineApprox
 
 from jdaviz.core.events import SnackbarMessage, NewViewerMessage, LinkUpdatedMessage
 from jdaviz.core.helpers import ImageConfigHelper
+from jdaviz.configs.imviz.wcs_utils import (
+    _get_rotated_nddata_from_label, get_compass_info
+)
 
 __all__ = ['Imviz', 'link_image_data']
+
+base_wcs_layer_label = 'Default orientation'
 
 
 class Imviz(ImageConfigHelper):
@@ -367,7 +373,6 @@ def get_reference_image_data(app):
 def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_use_affine=True,
                     error_on_fail=False, update_plugin=True):
     """(Re)link loaded data in Imviz with the desired link type.
-    All existing links will be replaced.
 
     .. note::
 
@@ -442,6 +447,25 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
                                  f" Clear markers with viewer.reset_markers() first")
 
     refdata, iref = get_reference_image_data(app)
+
+    # if linking via WCS, add WCS-only reference data layer:
+    insert_base_wcs_layer = (
+        link_type == 'wcs' and
+        base_wcs_layer_label not in [d.label for d in app.data_collection] and
+        not refdata.meta.get(app._wcs_only_label, False)
+    )
+
+    if insert_base_wcs_layer:
+        degn = get_compass_info(refdata.coords, refdata.shape)[-3]
+        # Default rotation is the same orientation as the original reference data:
+        rotation_angle = -degn * u.deg
+        ndd = _get_rotated_nddata_from_label(
+            app, refdata.label, rotation_angle
+        )
+        app._jdaviz_helper.load_data(ndd, base_wcs_layer_label)
+        app._change_reference_data(base_wcs_layer_label)
+        refdata, iref = get_reference_image_data(app)
+
     links_list = []
     ids0 = refdata.pixel_component_ids
     ndim_range = range(refdata.ndim)
@@ -518,6 +542,9 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
                                              wcs_fallback_scheme == 'pixels',
                                              wcs_use_affine,
                                              sender=app))
+        if insert_base_wcs_layer:
+            app._jdaviz_helper.default_viewer.state.reset_limits()
+
         # reset the progress spinner
         link_plugin.linking_in_progress = False
 

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -297,11 +297,13 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         if data_label == ref_label:
             return 'self'
 
+        if ref_label in self.state.wcs_only_layers:
+            return 'wcs'
+
         link_type = None
         for elink in self.session.application.data_collection.external_links:
             elink_labels = (elink.data1.label, elink.data2.label)
-            if (data_label in elink_labels and
-                    (ref_label in elink_labels or ref_label == self.jdaviz_app._wcs_only_label)):
+            if data_label in elink_labels and ref_label in elink_labels:
                 if isinstance(elink, LinkSame):  # Assumes WCS link never uses LinkSame
                     link_type = 'pixels'
                 else:  # If not pixels, must be WCS


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

For spacetelescope/jdaviz#2179.

This PR accomplishes the following:
* when linking via WCS, Imviz now inserts a WCS-only "base layer". "Default orientation" is the same orientation as the original reference data before WCS linking, so that the first loaded dataset appears in the same orientation when using either pixel or wcs linking.
* only allows reference data changes from one WCS-only layer to another
* forbids selecting a loaded image as reference data via clicks the data menu dropdown (WCS-only layers are the only ones allowed to become refdata when WCS linking)
* revises/simplifies the implementation of the `_rotated_gwcs` utility (same functionality)
* adds more checks to ensure that east is _left_ of north (not _right_ of north) by default, for any rotation angle
* bring the viewer back to the original sky position and zoom level after a reference data change

### Demo

This demo loads two JWST NIRCam exposures (~8k x 14k pixels each), one TESS Full Frame Image (2k x 2k), and two HST ACS exposures (4k x 4k each). That's a total of 168 million pixels across 5 images. The cell that sets up the screen capture below loads in each dataset, links by WCS, and loads a 45 deg rotation option. Considering all of that, the lag is pretty bearable!

https://github.com/bmorris3/jdaviz/assets/3497584/801e06fe-7b70-459b-b444-cda0b47b059e

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->