### PR TITLE
Links Control plugin+data menu revisions for support for WCS-only layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,6 +141,8 @@ Imviz
 - Added support for new ``CircularAnnulusROI`` subset from glue, including
   a new draw tool. [#2201, #2240]
 
+- Added viewer rotation support via Glue linking [#2179]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -14,6 +14,7 @@ from astropy.nddata import CCDData, NDData
 from astropy.io import fits
 from astropy.time import Time
 from astropy.utils.decorators import deprecated
+from astropy.wcs.wcsapi import BaseHighLevelWCS
 from echo import CallbackProperty, DictCallbackProperty, ListCallbackProperty
 from ipygoldenlayout import GoldenLayout
 from ipysplitpanes import SplitPanes
@@ -551,8 +552,14 @@ class Application(VuetifyTemplate, HubListener):
                 float(fov_sky_final / fov_sky_init)
             )
 
-        # re-center the viewer on previous location
-        viewer.center_on(sky_cen)
+        # only re-center the viewer if all data layers have WCS:
+        data_has_wcs = [
+            hasattr(d, 'coords') and isinstance(d.coords, BaseHighLevelWCS)
+            for d in viewer.data()
+        ]
+        if all(data_has_wcs):
+            # re-center the viewer on previous location.
+            viewer.center_on(sky_cen)
 
     def _link_new_data(self, reference_data=None, data_to_be_linked=None):
         """

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -482,7 +482,6 @@ class Application(VuetifyTemplate, HubListener):
             if is_wcs_only else 0
         )
         if layer_name not in self.state.layer_icons:
-            print('name', layer_name, 'is wcs', is_wcs_only)
             if is_wcs_only:
                 self.state.layer_icons = {**self.state.layer_icons,
                                           layer_name: wcs_only_refdata_icon}
@@ -495,7 +494,7 @@ class Application(VuetifyTemplate, HubListener):
     def _on_refdata_changed(self, msg):
         pass
 
-    def _change_reference_data(self, new_refdata_label):
+    def _change_reference_data(self, new_refdata_label, viewer_id=None):
         """
         Change reference data to Data with ``data_label``
         """
@@ -503,19 +502,22 @@ class Application(VuetifyTemplate, HubListener):
             # this method is only meant for Imviz for now
             return
 
-        viewer_id = f'{self.config}-0'  # Same as the ID in imviz.destroy_viewer()
-        viewer = self._jdaviz_helper.default_viewer
+        if viewer_id is None:
+            viewer = self._jdaviz_helper.default_viewer
+        else:
+            viewer = self.get_viewer(viewer_id)
+
         old_refdata = viewer.state.reference_data
+
+        if new_refdata_label == old_refdata.label:
+            # if there's no refdata change, don't do anything:
+            return
 
         # locate the central coordinate of old refdata in this viewer:
         sky_cen = viewer._get_center_skycoord(old_refdata)
 
         # estimate FOV in the viewer with old reference data:
         fov_sky_init = viewer._get_fov(old_refdata)
-
-        if new_refdata_label == old_refdata.label:
-            # if there's no refdata change, don't do anything:
-            return
 
         new_refdata = self.data_collection[new_refdata_label]
 
@@ -529,14 +531,14 @@ class Application(VuetifyTemplate, HubListener):
         viewer.state.reference_data = new_refdata
 
         # also update the viewer item's reference data label:
-        viewer_ref = self._jdaviz_helper.default_viewer.reference
+        viewer_ref = viewer.reference
         viewer_item = self._get_viewer_item(viewer_ref)
         viewer_item['reference_data_label'] = new_refdata.label
 
         self.hub.broadcast(ChangeRefDataMessage(
             new_refdata,
             viewer,
-            viewer_id=viewer_id,
+            viewer_id=viewer.reference,
             old=old_refdata,
             sender=self))
 
@@ -1886,7 +1888,8 @@ class Application(VuetifyTemplate, HubListener):
 
     def vue_change_reference_data(self, event):
         self._change_reference_data(
-            self._get_data_item_by_id(event['item_id'])['name']
+            self._get_data_item_by_id(event['item_id'])['name'],
+            viewer_id=self._get_viewer_item(event['id'])['name']
         )
 
     def set_data_visibility(self, viewer_reference, data_label, visible=True, replace=False):
@@ -2188,7 +2191,7 @@ class Application(VuetifyTemplate, HubListener):
             'linked_by_wcs': linked_by_wcs,
         }
 
-    def _on_new_viewer(self, msg, vid=None, name=None):
+    def _on_new_viewer(self, msg, vid=None, name=None, add_layers_to_viewer=False):
         """
         Callback for when the `~jdaviz.core.events.NewViewerMessage` message is
         raised. This method asks the application handler to generate a new
@@ -2239,6 +2242,10 @@ class Application(VuetifyTemplate, HubListener):
             viewer=viewer, vid=vid, name=name, reference=name
         )
 
+        if add_layers_to_viewer:
+            ref_data = self._jdaviz_helper.default_viewer.state.reference_data
+            new_viewer_item['reference_data_label'] = ref_data.label
+
         new_stack_item = self._create_stack_item(
             container='gl-stack',
             viewers=[new_viewer_item])
@@ -2255,6 +2262,12 @@ class Application(VuetifyTemplate, HubListener):
 
         # Send out a toast message
         self.hub.broadcast(ViewerAddedMessage(vid, sender=self))
+
+        if add_layers_to_viewer:
+            for layer_label in add_layers_to_viewer:
+                self.add_data_to_viewer(viewer.reference, layer_label)
+
+            viewer.state.reference_data = ref_data
 
         return viewer
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1941,8 +1941,12 @@ class Application(VuetifyTemplate, HubListener):
 
         # set visibility state of all applicable layers
         for layer in viewer.layers:
+            layer_is_wcs_only = getattr(layer.layer, 'meta', {}).get(self._wcs_only_label, False)
             if layer.layer.data.label == data_label:
-                if visible and not layer.visible:
+                if layer_is_wcs_only:
+                    layer.visible = False
+                    layer.update()
+                elif visible and not layer.visible:
                     layer.visible = True
                     layer.update()
                 else:
@@ -1964,11 +1968,10 @@ class Application(VuetifyTemplate, HubListener):
                 if id != data_id:
                     selected_items[id] = 'hidden'
 
-        # remove WCS-only data from selected items,
-        # add to wcs_only_layers:
+        # remove WCS-only data from selected items, add to wcs_only_layers:
         for layer in viewer.layers:
-            is_wcs_only = getattr(layer.layer, 'meta', {}).get(self._wcs_only_label, False)
-            if layer.layer.data.label == data_label and is_wcs_only:
+            layer_is_wcs_only = getattr(layer.layer, 'meta', {}).get(self._wcs_only_label, False)
+            if layer.layer.data.label == data_label and layer_is_wcs_only:
                 layer.visible = False
                 viewer.state.wcs_only_layers.append(data_label)
                 selected_items.pop(data_id)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -482,6 +482,7 @@ class Application(VuetifyTemplate, HubListener):
             if is_wcs_only else 0
         )
         if layer_name not in self.state.layer_icons:
+            print('name', layer_name, 'is wcs', is_wcs_only)
             if is_wcs_only:
                 self.state.layer_icons = {**self.state.layer_icons,
                                           layer_name: wcs_only_refdata_icon}
@@ -516,8 +517,15 @@ class Application(VuetifyTemplate, HubListener):
             # if there's no refdata change, don't do anything:
             return
 
-        # set the new reference data in the viewer:
         new_refdata = self.data_collection[new_refdata_label]
+
+        # make sure new refdata can be selected:
+        refdata_choices = [choice.label for choice in viewer.state.ref_data_helper.choices]
+        if new_refdata_label not in refdata_choices:
+            viewer.state.ref_data_helper.append_data(new_refdata)
+        viewer.state.ref_data_helper.refresh()
+
+        # set the new reference data in the viewer:
         viewer.state.reference_data = new_refdata
 
         # also update the viewer item's reference data label:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -473,11 +473,7 @@ class Application(VuetifyTemplate, HubListener):
         else:
             raise NotImplementedError(f"cannot recognize new layer from {msg}")
 
-<<<<<<< HEAD
         wcs_only_refdata_icon = 'mdi-rotate-left'
-=======
-        wcs_only_refdata_icon = 'mdi-compass-outline'
->>>>>>> 8021b45b (click data menu items to set as refdata)
         n_wcs_layers = (
             len([icon.startswith('mdi-rotate-left') for icon in self.state.layer_icons])
             if is_wcs_only else 0
@@ -2188,7 +2184,7 @@ class Application(VuetifyTemplate, HubListener):
             'selected_data_items': {},  # noqa data_id: visibility state (visible, hidden, mixed), READ-ONLY
             'visible_layers': {},  # label: {color, label_suffix}, READ-ONLY
             'wcs_only_layers': wcs_only_layers,
-            'reference_data_label': getattr(viewer.state.reference_data, 'label', None),
+            'reference_data_label': reference_data_label,
             'canvas_angle': 0,  # canvas rotation clockwise rotation angle in deg
             'canvas_flip_horizontal': False,  # canvas rotation horizontal flip
             'config': self.config,  # give viewer access to app config/layout

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -472,7 +472,11 @@ class Application(VuetifyTemplate, HubListener):
         else:
             raise NotImplementedError(f"cannot recognize new layer from {msg}")
 
+<<<<<<< HEAD
         wcs_only_refdata_icon = 'mdi-rotate-left'
+=======
+        wcs_only_refdata_icon = 'mdi-compass-outline'
+>>>>>>> 8021b45b (click data menu items to set as refdata)
         n_wcs_layers = (
             len([icon.startswith('mdi-rotate-left') for icon in self.state.layer_icons])
             if is_wcs_only else 0
@@ -2165,7 +2169,7 @@ class Application(VuetifyTemplate, HubListener):
             'selected_data_items': {},  # noqa data_id: visibility state (visible, hidden, mixed), READ-ONLY
             'visible_layers': {},  # label: {color, label_suffix}, READ-ONLY
             'wcs_only_layers': wcs_only_layers,
-            'reference_data_label': reference_data_label,
+            'reference_data_label': getattr(viewer.state.reference_data, 'label', None),
             'canvas_angle': 0,  # canvas rotation clockwise rotation angle in deg
             'canvas_flip_horizontal': False,  # canvas rotation horizontal flip
             'config': self.config,  # give viewer access to app config/layout

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2158,6 +2158,7 @@ class Application(VuetifyTemplate, HubListener):
 
         reference_data = getattr(viewer.state, 'reference_data', None)
         reference_data_label = getattr(reference_data, 'label', None)
+        linked_by_wcs = getattr(viewer.state, 'linked_by_wcs', False)
 
         return {
             'id': vid,
@@ -2175,7 +2176,9 @@ class Application(VuetifyTemplate, HubListener):
             'config': self.config,  # give viewer access to app config/layout
             'data_open': False,
             'collapse': True,
-            'reference': reference}
+            'reference': reference,
+            'linked_by_wcs': linked_by_wcs,
+        }
 
     def _on_new_viewer(self, msg, vid=None, name=None):
         """

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -17,7 +17,7 @@
 
 <script>
 module.exports = {
-  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark', 'is_ref_data'],
+  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark', 'is_ref_data', 'linked_by_wcs'],
   computed: {
     borderStyle() {
       if (this.$props.linewidth > 0) { 
@@ -28,7 +28,7 @@ module.exports = {
   },
   methods: {
     isRefData() {
-      if (this.$props.is_ref_data === undefined) {
+      if (!this.$props.linked_by_wcs || this.$props.is_ref_data === undefined) {
         return false
       } else {
         return this.$props.is_ref_data

--- a/jdaviz/components/plugin_dataset_select.vue
+++ b/jdaviz/components/plugin_dataset_select.vue
@@ -17,7 +17,7 @@
     <template slot="selection" slot-scope="data">
       <div class="single-line">
         <span>
-          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true" :is_wcs_only="isWCSOnlyLayer()"></j-layer-viewer-icon>
+          <j-layer-viewer-icon v-if="data.item.icon" span_style="margin-right: 4px" :icon="data.item.icon" :prevent_invert_if_dark="true"></j-layer-viewer-icon>
           {{ data.item.label }}
         </span>
       </div>
@@ -36,13 +36,7 @@
 </template>
 <script>
 module.exports = {
-  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry'],
-  methods: {
-    isWCSOnlyLayer(item) {
-      const wcsOnly = Object.keys(this.$props.viewer.wcs_only_layers).includes(item.name)
-      return wcsOnly
-    },
-  }
+  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry']
 };
 </script>
 

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -49,6 +49,7 @@
             :icon="layer_icons[item.name]"
             :viewer="viewer"
             :multi_select="multi_select"
+            :linked_by_wcs="linkedByWcs()"
             @data-item-visibility="$emit('data-item-visibility', $event)"
             @data-item-unload="$emit('data-item-unload', $event)"
             @data-item-remove="$emit('data-item-remove', $event)"
@@ -60,7 +61,7 @@
           <v-row key="extra-items-expand" style="padding-left: 25px; margin-right: 0px; padding-bottom: 4px; background-color: #E3F2FD"> 
             <span 
               @click="toggleShowExtraItems"
-              class='text--primary' 
+              class='text--primary'
               style="overflow-wrap: anywhere; font-size: 12pt; padding-top: 6px; padding-left: 6px; cursor: pointer"
             >
               <v-icon class='invert-if-dark'>{{showExtraItems ? 'mdi-chevron-double-up' : 'mdi-chevron-double-down'}}</v-icon>
@@ -68,23 +69,55 @@
                 {{showExtraItems ? 'hide other row data not in viewer' : 'show other row data not in viewer'}}
               </span>
               <span v-else>
-                {{showExtraItems ? 'hide data not in viewer' : 'show data not in viewer'}}                
+                {{showExtraItems ? 'hide data not in viewer' : 'show data not in viewer'}}
               </span>
             </span>
           </v-row>
 
           <v-row v-if="showExtraItems" v-for="item in extraDataItems"  :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
+            <div v-if="linkedByWcs()">
             <j-viewer-data-select-item
               :item="item"
               :icon="layer_icons[item.name]"
               :viewer="viewer"
               :multi_select="multi_select"
+              :linked_by_wcs="linkedByWcs()"
+              @data-item-visibility="$emit('data-item-visibility', $event)"
+              @data-item-remove="$emit('data-item-remove', $event)"
+              @change-reference-data="$emit('change-reference-data', $event)"
+            ></j-viewer-data-select-item>
+            </div>
+          </v-row>
+        </div>
+
+        <div v-if="linkedByWcs()" style="margin-bottom: -8px;">
+          <v-row key="wcs-only-items-expand" style="padding-left: 25px; margin-right: 0px; padding-bottom: 4px; background-color: #E3F2FD">
+            <span
+              @click="toggleShowWcsOnlyItems"
+              class='text--primary'
+              style="overflow-wrap: anywhere; font-size: 12pt; padding-top: 6px; padding-left: 6px; cursor: pointer"
+            >
+              <v-icon class='invert-if-dark'>{{showWcsOnlyItems ? 'mdi-chevron-double-up' : 'mdi-chevron-double-down'}}</v-icon>
+              <span>
+                {{showWcsOnlyItems ? 'hide orientation options' : 'show orientation options'}}
+              </span>
+            </span>
+          </v-row>
+
+          <v-row v-if="showWcsOnlyItems" v-for="item in wcsOnlyItems"  :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
+            <j-viewer-data-select-item
+              :item="item"
+              :icon="layer_icons[item.name]"
+              :viewer="viewer"
+              :multi_select="multi_select"
+              :linked_by_wcs="linkedByWcs()"
               @data-item-visibility="$emit('data-item-visibility', $event)"
               @data-item-remove="$emit('data-item-remove', $event)"
               @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select-item>
           </v-row>
         </div>
+
       </v-list>
     </v-menu>
   </j-tooltip>
@@ -114,7 +147,8 @@ module.exports = {
       multi_select: multi_select,
       showExtraItems: false,
       valueTrunc: this.value,
-      uncertTrunc: this.uncertainty
+      uncertTrunc: this.uncertainty,
+      showWcsOnlyItems: false
     }
   },
   methods: {
@@ -126,15 +160,13 @@ module.exports = {
     },
     dataItemInViewer(item, returnExtraItems) {
       const inViewer = Object.keys(this.$props.viewer.selected_data_items).includes(item.id)
-      //console.log(item.name+"  "+inViewer)
       if (returnExtraItems) {
         return (!inViewer && (item.meta.mosviz_row === this.$props.app_settings.mosviz_row))
       }
       return inViewer
     },
-    wcsOnlyItemInViewer(item) {
-      const wcsOnly = Object.keys(this.$props.viewer.wcs_only_layers).includes(item.name)
-      return wcsOnly
+    wcsOnlyItem(item) {
+      return item.type == 'wcs-only'
     },
     itemIsVisible(item, returnExtraItems) {
       if (this.$props.viewer.config === 'mosviz') {
@@ -172,7 +204,7 @@ module.exports = {
           return (item.ndims === 2 || item.type==='trace') && this.dataItemInViewer(item, returnExtraItems)
         }
       } else if (this.$props.viewer.config === 'imviz') {
-        return this.dataItemInViewer(item, returnExtraItems) && !this.wcsOnlyItemInViewer(item)
+        return this.dataItemInViewer(item, returnExtraItems && !this.wcsOnlyItem(item))
       }
       // for any situation not covered above, default to showing the entry
       return this.dataItemInViewer(item, returnExtraItems)
@@ -183,20 +215,25 @@ module.exports = {
     },
     toggleMultiSelect() {
       this.multi_select = !this.multi_select
-      if (this.multi_select === false){
+      if (this.multi_select === false) {
         // If we're toggling to single select, set the first item visibility to replace the rest
         // Find the "first" item
-        for (item_index in this.filteredDataItems){
+        for (item_index in this.filteredDataItems) {
           if (this.$props.viewer.selected_data_items[this.filteredDataItems[item_index].id] === 'visible') {
             this.$emit('data-item-visibility', {
               id: this.$props.viewer.id,
               item_id: this.filteredDataItems[item_index].id,
               visible: true,
-              replace: true})
+              replace: true
+            })
             break;
           }
         }
       }
+    },
+    toggleShowWcsOnlyItems() {
+      // toggle the visibility of the WCS-only items in the menu
+      this.showWcsOnlyItems = !this.showWcsOnlyItems
     },
     isRefData() {
       return this.$props.item.viewer.reference_data_label === this.$props.item.name
@@ -206,6 +243,9 @@ module.exports = {
         id: this.$props.viewer.id,
         item_id: this.$props.item.id
       })
+    },
+    linkedByWcs() {
+      return this.$props.viewer.linked_by_wcs
     }
   },
   computed: {
@@ -228,6 +268,9 @@ module.exports = {
     },
     extraDataItems() {
       return this.$props.data_items.filter((item) => this.itemIsVisible(item, true))
+    },
+    wcsOnlyItems() {
+      return this.$props.data_items.filter((item) => this.wcsOnlyItem(item))
     },
   }
 };

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -28,6 +28,9 @@
         <span>
           {{itemNameExtension}}
         </span>
+        <span v-if="this.$props.viewer.config === 'imviz' && isRefData()">
+          {{"*"}}
+        </span>
       </div>
       </span>
     </j-tooltip>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -27,9 +27,6 @@
         <span>
           {{itemNameExtension}}
         </span>
-        <span v-if="this.$props.viewer.config === 'imviz' && isRefData()">
-          {{"*"}}
-        </span>
       </div>
       </span>
     </j-tooltip>

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -19,8 +19,7 @@
       :style="dataMenuTooltip !== null ? 'cursor: pointer;' : 'cursor: default;'"
       @click="selectRefData"
     >
-      <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE" :is_ref_data="isRefData()"></j-layer-viewer-icon>
-
+      <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE" :is_ref_data="isRefData()" :linked_by_wcs="linkedByWcs()"></j-layer-viewer-icon>
       <div class="text-ellipsis-middle" style="font-weight: 500;">
         <span>
           {{itemNamePrefix}}
@@ -78,7 +77,7 @@ module.exports = {
       })
     },
     selectRefData() {
-      if (!this.isRefData() && this.$props.item.type === 'wcs-only') {
+      if (this.linkedByWcs() && !this.isRefData() && this.isWCSOnly()) {
         this.$emit('change-reference-data', {
           id: this.$props.viewer.id,
           item_id: this.$props.item.id
@@ -87,6 +86,12 @@ module.exports = {
     },
     isRefData() {
       return this.$props.viewer.reference_data_label == this.$props.item.name
+    },
+    linkedByWcs() {
+      return this.$props.viewer.linked_by_wcs
+    },
+    isWCSOnly() {
+      return this.$props.item.type === 'wcs-only'
     }
   },
   computed: {
@@ -101,7 +106,7 @@ module.exports = {
     itemNameExtension() {
       if (this.$props.item.name.indexOf("[") !== -1) {
         // return the LAST [ and everything FOLLOWING
-        return '['+this.$props.item.name.split('[').slice(-1)
+        return '[' + this.$props.item.name.split('[').slice(-1)
       } else {
         return ''
       }
@@ -133,7 +138,7 @@ module.exports = {
         } else if (this.$props.viewer.reference === 'mask-viewer') {
           return this.$props.item.name.indexOf('[MASK]') === -1
         } else if (this.$props.viewer.reference === 'spectrum-viewer') {
-          return this.$props.item.name.indexOf('[FLUX]') === -1          
+          return this.$props.item.name.indexOf('[FLUX]') === -1
         }
       } else if (this.$props.viewer.config === 'specviz2d') {
         if (this.$props.viewer.reference === 'spectrum-2d-viewer') {
@@ -169,9 +174,9 @@ module.exports = {
       }
     },
     dataMenuTooltip() {
-      if (this.$props.viewer.config === 'imviz' && this.isRefData()) {
+      if (this.linkedByWcs() && this.$props.viewer.config === 'imviz' && this.isRefData()) {
         return 'Current viewer orientation'
-      } else if (this.$props.viewer.config === 'imviz' && this.$props.item.type === 'wcs-only') {
+      } else if (this.linkedByWcs() && this.$props.viewer.config === 'imviz' && this.$props.item.type === 'wcs-only') {
         return 'Set viewer orientation'
       } else {
         return null

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -190,23 +190,21 @@ class Imviz(ImageConfigHelper):
         # above instead of having to refind it
         applied_labels = []
         applied_visible = []
+        applied_is_wcs = []
         for data in self.app.data_collection:
             label = data.label
             if label not in prev_data_labels:
                 applied_labels.append(label)
-                if not data.meta.get(self.app._wcs_only_label, False):
-                    applied_visible.append(True)
-                else:
-                    applied_visible.append(False)
+                applied_visible.append(True)
+                applied_is_wcs.append(data.meta.get(self.app._wcs_only_label, False))
 
         if show_in_viewer is True:
             show_in_viewer = f"{self.app.config}-0"
 
-        # NOTE: We will never try to batch load WCS-only, but if we do, add extra logic
-        #       in batch_load within core/helpers.py module.
         if self._in_batch_load and show_in_viewer:
-            for applied_label in applied_labels:
-                self._delayed_show_in_viewer_labels[applied_label] = show_in_viewer
+            for applied_label, layer_is_wcs in zip(applied_labels, applied_is_wcs):
+                if not layer_is_wcs:
+                    self._delayed_show_in_viewer_labels[applied_label] = show_in_viewer
 
         elif do_link:
             if 'Links Control' not in self.plugins.keys():

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 import numpy as np
 import astropy.units as u
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.wcs.wcsapi import BaseHighLevelWCS
+from gwcs.wcs import WCS as GWCS
 from glue.core import BaseData
 from glue.core.link_helpers import LinkSame
 from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink, NoAffineApproximation
@@ -392,7 +394,7 @@ def get_reference_image_data(app, viewer_id=None):
     return refdata, iref
 
 
-def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_use_affine=True,
+def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_affine=True,
                     error_on_fail=False, update_plugin=True):
     """(Re)link loaded data in Imviz with the desired link type.
 
@@ -446,7 +448,21 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
     if link_type == 'wcs' and wcs_fallback_scheme not in (None, 'pixels'):
         raise ValueError("wcs_fallback_scheme must be None or 'pixels', "
                          f"got {wcs_fallback_scheme}")
-
+    if link_type == 'wcs':
+        all_data_have_wcs = all([
+            hasattr(d, 'coords') and isinstance(d.coords, (BaseHighLevelWCS, GWCS))
+            for d in app.data_collection
+        ])
+        if not all_data_have_wcs:
+            if wcs_fallback_scheme is None:
+                if error_on_fail:
+                    raise ValueError("link_type can only be 'wcs' when wcs_fallback_scheme "
+                                     "is 'None' if all data have valid WCS.")
+                else:
+                    return
+            else:
+                # fall back on pixel linking
+                link_type = 'pixels'
     # if the plugin exists, send a message so that the plugin's state is updated and spinner
     # is shown (the plugin will make a call back here)
     if 'imviz-links-control' in [item['name'] for item in app.state.tray_items]:
@@ -591,4 +607,3 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
         # if changing from one link type to another, reset the limits:
         if old_link_type is not None and link_type != old_link_type:
             viewer.state.reset_limits()
-

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -53,9 +53,14 @@ class Imviz(ImageConfigHelper):
 
         # Cannot assign data to real Data because it loads but it will
         # not update checkbox in Data menu.
+
+        # add WCS-only layers from all viewers into the new viewer
+        add_layers_to_viewer = get_wcs_only_layer_labels(self.app)
+
         return self.app._on_new_viewer(
             NewViewerMessage(ImvizImageView, data=None, sender=self.app),
-            vid=viewer_name, name=viewer_name)
+            vid=viewer_name, name=viewer_name,
+            add_layers_to_viewer=add_layers_to_viewer)
 
     def destroy_viewer(self, viewer_id):
         """Destroy a viewer associated with the given ID.
@@ -340,6 +345,19 @@ def layer_is_table_data(layer):
     return isinstance(layer, BaseData) and layer.ndim == 1
 
 
+def get_bottom_layer(viewer):
+    """
+    Get the first-loaded image layer in Imviz.
+    """
+    return [lyr.layer for lyr in viewer.layers
+            if lyr.visible and layer_is_image_data(lyr.layer)][0]
+
+
+def get_wcs_only_layer_labels(app):
+    return [data.label for data in app.data_collection
+            if layer_is_wcs_only(data)]
+
+
 def get_top_layer_index(viewer):
     """Get index of the top visible image layer in Imviz.
     This is because when blinked, first layer might not be top visible layer.
@@ -349,11 +367,15 @@ def get_top_layer_index(viewer):
             if lyr.visible and layer_is_image_data(lyr.layer)][-1]
 
 
-def get_reference_image_data(app):
+def get_reference_image_data(app, viewer_id=None):
     """
     Return the reference data in the first image viewer and its index
     """
-    refdata = app._jdaviz_helper.default_viewer.state.reference_data
+    if viewer_id is None:
+        refdata = app._jdaviz_helper.default_viewer.state.reference_data
+    else:
+        viewer = app.get_viewer_by_id(viewer_id)
+        refdata = viewer.state.reference_data
 
     if refdata is not None:
         iref = app.data_collection.index(refdata)
@@ -416,7 +438,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
         Invalid inputs or reference data.
 
     """
-    if len(app.data_collection) <= 1:  # No need to link, we are done.
+    if len(app.data_collection) <= 1 and link_type != 'wcs':  # No need to link, we are done.
         return
 
     if link_type not in ('pixels', 'wcs'):
@@ -464,7 +486,13 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
             app, refdata.label, rotation_angle
         )
         app._jdaviz_helper.load_data(ndd, base_wcs_layer_label)
-        app._change_reference_data(base_wcs_layer_label)
+
+        # set base layer to reference data in all viewers:
+        for viewer_id in app.get_viewer_ids():
+            app._change_reference_data(
+                base_wcs_layer_label, viewer_id=viewer_id
+            )
+
         refdata, iref = get_reference_image_data(app)
 
     links_list = []
@@ -543,8 +571,12 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
                                              wcs_fallback_scheme == 'pixels',
                                              wcs_use_affine,
                                              sender=app))
+
         if insert_base_wcs_layer:
-            app._jdaviz_helper.default_viewer.state.reset_limits()
+            # update all viewer items with reference data:
+            for viewer_id in app.get_viewer_ids():
+                viewer_item = app._get_viewer_item(viewer_id)
+                viewer_item['reference_data_label'] = refdata.label
 
         # reset the progress spinner
         link_plugin.linking_in_progress = False

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -446,6 +446,7 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
                                  f"'{link_type}') when markers are present. "
                                  f" Clear markers with viewer.reset_markers() first")
 
+    old_link_type = getattr(app, '_link_type', None)
     refdata, iref = get_reference_image_data(app)
 
     # if linking via WCS, add WCS-only reference data layer:
@@ -549,5 +550,13 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme='pixels', wcs_u
         link_plugin.linking_in_progress = False
 
     for viewer in app._viewer_store.values():
+        wcs_linked = link_type == 'wcs'
         # viewer-state needs to know link type for reset_limits behavior
-        viewer.state.linked_by_wcs = link_type == 'wcs'
+        viewer.state.linked_by_wcs = wcs_linked
+        # also need to store a copy in the viewer item for the data dropdown to access
+        viewer_item['linked_by_wcs'] = wcs_linked
+
+        # if changing from one link type to another, reset the limits:
+        if old_link_type is not None and link_type != old_link_type:
+            viewer.state.reset_limits()
+

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -610,5 +610,5 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         viewer_item['linked_by_wcs'] = wcs_linked
 
         # if changing from one link type to another, reset the limits:
-        if old_link_type is not None and link_type != old_link_type:
+        if link_type != old_link_type:
             viewer.state.reset_limits()

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -351,8 +351,11 @@ def get_bottom_layer(viewer):
     """
     Get the first-loaded image layer in Imviz.
     """
-    return [lyr.layer for lyr in viewer.layers
-            if lyr.visible and layer_is_image_data(lyr.layer)][0]
+    image_layers = [lyr.layer for lyr in viewer.layers
+                    if lyr.visible and layer_is_image_data(lyr.layer)]
+    if not len(image_layers):
+        return image_layers
+    return image_layers[0]
 
 
 def get_wcs_only_layer_labels(app):
@@ -486,6 +489,8 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
 
     old_link_type = getattr(app, '_link_type', None)
     refdata, iref = get_reference_image_data(app)
+    # default reference layer is the first-loaded image:
+    default_reference_layer = get_bottom_layer(app._jdaviz_helper.default_viewer)
 
     # if linking via WCS, add WCS-only reference data layer:
     insert_base_wcs_layer = (
@@ -495,11 +500,11 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
     )
 
     if insert_base_wcs_layer:
-        degn = get_compass_info(refdata.coords, refdata.shape)[-3]
+        degn = get_compass_info(default_reference_layer.coords, default_reference_layer.shape)[-3]
         # Default rotation is the same orientation as the original reference data:
         rotation_angle = -degn * u.deg
         ndd = _get_rotated_nddata_from_label(
-            app, refdata.label, rotation_angle
+            app, default_reference_layer.label, rotation_angle
         )
         app._jdaviz_helper.load_data(ndd, base_wcs_layer_label)
 

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -352,7 +352,7 @@ def get_bottom_layer(viewer):
     image_layers = [lyr.layer for lyr in viewer.layers
                     if lyr.visible and layer_is_image_data(lyr.layer)]
     if not len(image_layers):
-        return image_layers
+        return None
     return image_layers[0]
 
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -202,7 +202,11 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     @property
     def rotation_angle_deg(self):
         if self.rotation_angle is not None:
-            return self.rotation_angle * u.deg
+            if (
+                (isinstance(self.rotation_angle, str) and len(self.rotation_angle)) or
+                isinstance(self.rotation_angle, float)
+            ):
+                return float(self.rotation_angle) * u.deg
         return 0 * u.deg
 
     def create_new_orientation_from_data(self, data):

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -1,17 +1,23 @@
-from traitlets import List, Unicode, Bool, observe
+from traitlets import List, Unicode, Bool, Float, observe
 
 from glue.core.message import DataCollectionAddMessage
 
-from jdaviz.configs.imviz.helper import link_image_data
-from jdaviz.core.events import LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage
+import astropy.units as u
+from jdaviz.configs.imviz.helper import link_image_data, get_bottom_layer
+from jdaviz.configs.imviz.wcs_utils import get_compass_info, _get_rotated_nddata_from_label
+from jdaviz.core.events import (
+    LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage
+)
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, SelectPluginComponent
+from jdaviz.core.template_mixin import PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['LinksControl']
 
+link_type_msg_to_trait = {'pixels': 'Pixels', 'wcs': 'WCS'}
 
-@tray_registry('imviz-links-control', label="Links Control")
+
+@tray_registry('imviz-links-control', label="Links Control", viewer_requirements="image")
 class LinksControl(PluginTemplateMixin):
     """
     See the :ref:`Links Control Plugin Documentation <imviz-link-control>` for more details.
@@ -41,6 +47,18 @@ class LinksControl(PluginTemplateMixin):
     need_clear_markers = Bool(False).tag(sync=True)
     linking_in_progress = Bool(False).tag(sync=True)
 
+    # rotation angle, counterclockwise [degrees]
+    rotation_angle = Unicode("0").tag(sync=True)
+    set_on_create = Bool(True).tag(sync=True)
+    relink = Bool(True).tag(sync=True)
+
+    viewer_items = List().tag(sync=True)
+    viewer_selected = Unicode().tag(sync=True)
+    layer_items = List().tag(sync=True)
+    layer_selected = Unicode().tag(sync=True)
+
+    multiselect = Bool(False).tag(sync=True)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -48,6 +66,10 @@ class LinksControl(PluginTemplateMixin):
                                                items='link_type_items',
                                                selected='link_type_selected',
                                                manual_options=['Pixels', 'WCS'])
+
+        self.viewer = ViewerSelect(self, 'viewer_items', 'viewer_selected', 'multiselect')
+        self.layer = LayerSelect(self, 'layer_items', 'layer_selected', 'viewer_selected',
+                                 'multiselect', only_wcs_layers=True)  # noqa
 
         self.hub.subscribe(self, LinkUpdatedMessage,
                            handler=self._on_link_updated)
@@ -61,12 +83,20 @@ class LinksControl(PluginTemplateMixin):
         self.hub.subscribe(self, MarkersChangedMessage,
                            handler=self._on_markers_changed)
 
+        self.hub.subscribe(self, ChangeRefDataMessage,
+                           handler=self._on_refdata_change)
+
     @property
     def user_api(self):
-        return PluginUserApi(self, expose=('link_type', 'wcs_use_affine'))
+        return PluginUserApi(
+            self,
+            expose=(
+                'link_type', 'wcs_use_affine', 'viewer', 'layer'
+            )
+        )
 
     def _on_link_updated(self, msg):
-        self.link_type.selected = {'pixels': 'Pixels', 'wcs': 'WCS'}[msg.link_type]
+        self.link_type.selected = link_type_msg_to_trait[msg.link_type]
         self.linking_in_progress = True
         self.wcs_use_fallback = msg.wcs_use_fallback
         self.wcs_use_affine = msg.wcs_use_affine
@@ -126,9 +156,94 @@ class LinksControl(PluginTemplateMixin):
             self.wcs_use_affine = True
 
         self._link_image_data()
-
         self.linking_in_progress = False
 
     def vue_reset_markers(self, *args):
         for viewer in self.app._viewer_store.values():
             viewer.reset_markers()
+
+    def _get_wcs_angles(self):
+        degn, dege, flip = get_compass_info(self.ref_data.coords, self.ref_data.shape)[-3:]
+        return degn, dege, flip
+
+    @property
+    def rotation_angle_deg(self):
+        return float(self.rotation_angle) * u.deg
+
+    def create_new_orientation_from_data(self, data):
+        # Default rotation is the same orientation as the original reference data:
+        degn = get_compass_info(data.coords, data.shape)[-3]
+        ndd = _get_rotated_nddata_from_label(
+            self.app, data.label, -degn * u.deg + self.rotation_angle_deg
+        )
+        data_label = f'CCW {self.rotation_angle} deg'
+        self.app._jdaviz_helper.load_data(
+            ndd, data_label=data_label
+        )
+        if self.relink:
+            # this will trigger linking by wcs if not already selected:
+            self.link_type_selected = 'WCS'
+
+        # add orientation layer to all viewers:
+        self._add_data_to_all_viewers(data_label)
+
+        if self.set_on_create:
+            # set orientation (reference data layer) to be the new option:
+            self.app._change_reference_data(
+                data_label, viewer_id=self.viewer.selected
+            )
+
+    def _add_data_to_all_viewers(self, data_label):
+        for viewer in self.viewer.choices:
+            self.app.add_data_to_viewer(viewer, data_label)
+
+    def vue_create_new_orientation_from_data(self, *args, **kwargs):
+        if 'reference_data' not in kwargs:
+            # if not specified, use first-loaded image layer as the
+            # default rotation:
+            viewer = self.app.get_viewer(self.viewer.selected)
+            reference_data = get_bottom_layer(viewer)
+        self.create_new_orientation_from_data(reference_data)
+
+    @observe('layer_selected')
+    def _change_reference_data(self, *args, **kwargs):
+        if self._refdata_change_available:
+            self.app._change_reference_data(
+                self.layer.selected, viewer_id=self.viewer.selected
+            )
+
+    def _on_refdata_change(self, msg={}):
+        # don't select until viewer is available:
+        if hasattr(self, 'viewer'):
+            ref_data = self.ref_data
+            viewer = self.app.get_viewer(self.viewer.selected)
+
+            # don't select until reference data are available:
+            if ref_data is not None:
+                self.layer.selected = ref_data.label
+                link_type = viewer.get_link_type(ref_data.label)
+                if link_type != 'self':
+                    self.link_type_selected = link_type_msg_to_trait[link_type]
+            elif not len(viewer.data()):
+                self.link_type_selected = link_type_msg_to_trait['pixels']
+
+    @property
+    def ref_data(self):
+        return self.app.get_viewer_by_id(self.viewer.selected).state.reference_data
+
+    @property
+    def _refdata_change_available(self):
+        viewer = self.app.get_viewer(self.viewer.selected)
+        ref_data = self.ref_data
+        return (
+            ref_data is not None and len(viewer.data()) and
+            len(self.layer.selected) and len(self.viewer.selected)
+        )
+
+    @observe('viewer_selected')
+    def _on_viewer_change(self, msg={}):
+        # don't update choices until viewer is available:
+        if hasattr(self, 'viewer'):
+            viewer = self.app.get_viewer(self.viewer.selected)
+            self.layer.choices = viewer.state.wcs_only_layers
+            self.layer.selected = self.ref_data.label

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -1,6 +1,8 @@
-from traitlets import List, Unicode, Bool, Float, observe
+from traitlets import List, Unicode, Bool, observe
 
 from glue.core.message import DataCollectionAddMessage
+from glue.core.subset import Subset
+from glue.core.subset_group import GroupedSubset
 
 import astropy.units as u
 from jdaviz.configs.imviz.helper import link_image_data, get_bottom_layer
@@ -9,7 +11,9 @@ from jdaviz.core.events import (
     LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage
 )
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect
+from jdaviz.core.template_mixin import (
+    PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect
+)
 from jdaviz.core.user_api import PluginUserApi
 
 __all__ = ['LinksControl']
@@ -235,9 +239,16 @@ class LinksControl(PluginTemplateMixin):
     def _refdata_change_available(self):
         viewer = self.app.get_viewer(self.viewer.selected)
         ref_data = self.ref_data
+        selected_layer = [lyr.layer for lyr in viewer.layers
+                          if lyr.layer.label == self.layer.selected]
+        if len(selected_layer):
+            is_subset = isinstance(selected_layer[0], (Subset, GroupedSubset))
+        else:
+            is_subset = False
         return (
             ref_data is not None and len(viewer.data()) and
-            len(self.layer.selected) and len(self.viewer.selected)
+            len(self.layer.selected) and len(self.viewer.selected) and
+            not is_subset
         )
 
     @observe('viewer_selected')

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -16,6 +16,7 @@ from jdaviz.configs.imviz.wcs_utils import (
 from jdaviz.core.events import (
     LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage
 )
+from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (
     PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelectMixin, AutoTextField
@@ -59,10 +60,10 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     linking_in_progress = Bool(False).tag(sync=True)
 
     # rotation angle, counterclockwise [degrees]
-    rotation_angle = Unicode("0").tag(sync=True)
+    rotation_angle = FloatHandleEmpty(0).tag(sync=True)
     set_on_create = Bool(True).tag(sync=True)
     relink = Bool(True).tag(sync=True)
-    east_left = Bool(True).tag(sync=True)
+    east_left = Bool(True).tag(sync=True)  # set convention for east left of north
 
     icon_nuer = Unicode(
         read_icon(os.path.join(ICON_DIR, 'right-east.svg'), 'svg+xml')
@@ -200,8 +201,8 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
 
     @property
     def rotation_angle_deg(self):
-        if len(self.rotation_angle):
-            return float(self.rotation_angle) * u.deg
+        if self.rotation_angle is not None:
+            return self.rotation_angle * u.deg
         return 0 * u.deg
 
     def create_new_orientation_from_data(self, data):
@@ -280,7 +281,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     def _reset_default_rotation_options(self):
         # return rotation options to these defaults:
         self.east_left = True
-        self.rotation_angle = "0"
+        self.rotation_angle = 0
 
     @property
     def ref_data(self):
@@ -319,7 +320,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
         """
         if label not in self.layer.choices:
             degn = self._get_wcs_angles()[-3]
-            self.rotation_angle = str(degn)
+            self.rotation_angle = degn
             self.east_left = True
             self.set_on_create = set_on_create
             self.new_layer_label_default = label
@@ -334,7 +335,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
         """
         if label not in self.layer.choices:
             degn = self._get_wcs_angles()[-3]
-            self.rotation_angle = str(180 - degn)
+            self.rotation_angle = 180 - degn
             self.east_left = False
             self.set_on_create = set_on_create
             self.new_layer_label_default = label

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -18,7 +18,7 @@ from jdaviz.core.events import (
 )
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (
-    PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect, AutoTextField
+    PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelectMixin, AutoTextField
 )
 from jdaviz.core.user_api import PluginUserApi
 from jdaviz.core.tools import ICON_DIR
@@ -29,7 +29,7 @@ link_type_msg_to_trait = {'pixels': 'Pixels', 'wcs': 'WCS'}
 
 
 @tray_registry('imviz-links-control', label="Links Control", viewer_requirements="image")
-class LinksControl(PluginTemplateMixin):
+class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     """
     See the :ref:`Links Control Plugin Documentation <imviz-link-control>` for more details.
 
@@ -90,9 +90,6 @@ class LinksControl(PluginTemplateMixin):
                                                selected='link_type_selected',
                                                manual_options=['Pixels', 'WCS'])
 
-        self.viewer = ViewerSelect(
-            self, 'viewer_items', 'viewer_selected', 'multiselect'
-        )
         self.layer = LayerSelect(
             self, 'layer_items', 'layer_selected', 'viewer_selected',
             'multiselect', only_wcs_layers=True
@@ -121,7 +118,8 @@ class LinksControl(PluginTemplateMixin):
         return PluginUserApi(
             self,
             expose=(
-                'link_type', 'wcs_use_affine', 'viewer', 'layer'
+                'link_type', 'wcs_use_affine', 'viewer',
+                'layer', 'rotation_angle', 'east_left'
             )
         )
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -1,20 +1,27 @@
+import os
 from traitlets import List, Unicode, Bool, observe
 
 from glue.core.message import DataCollectionAddMessage
 from glue.core.subset import Subset
 from glue.core.subset_group import GroupedSubset
+from glue_jupyter.common.toolbar_vuetify import read_icon
 
 import astropy.units as u
-from jdaviz.configs.imviz.helper import link_image_data, get_bottom_layer
-from jdaviz.configs.imviz.wcs_utils import get_compass_info, _get_rotated_nddata_from_label
+from jdaviz.configs.imviz.helper import (
+    link_image_data, get_bottom_layer, base_wcs_layer_label
+)
+from jdaviz.configs.imviz.wcs_utils import (
+    get_compass_info, _get_rotated_nddata_from_label
+)
 from jdaviz.core.events import (
     LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage
 )
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (
-    PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect
+    PluginTemplateMixin, SelectPluginComponent, LayerSelect, ViewerSelect, AutoTextField
 )
 from jdaviz.core.user_api import PluginUserApi
+from jdaviz.core.tools import ICON_DIR
 
 __all__ = ['LinksControl']
 
@@ -55,11 +62,23 @@ class LinksControl(PluginTemplateMixin):
     rotation_angle = Unicode("0").tag(sync=True)
     set_on_create = Bool(True).tag(sync=True)
     relink = Bool(True).tag(sync=True)
+    east_left = Bool(True).tag(sync=True)
+
+    icon_nuer = Unicode(
+        read_icon(os.path.join(ICON_DIR, 'right-east.svg'), 'svg+xml')
+    ).tag(sync=True)
+    icon_nuel = Unicode(
+        read_icon(os.path.join(ICON_DIR, 'left-east.svg'), 'svg+xml')
+    ).tag(sync=True)
 
     viewer_items = List().tag(sync=True)
     viewer_selected = Unicode().tag(sync=True)
     layer_items = List().tag(sync=True)
     layer_selected = Unicode().tag(sync=True)
+
+    new_layer_label = Unicode().tag(sync=True)
+    new_layer_label_default = Unicode().tag(sync=True)
+    new_layer_label_auto = Bool(True).tag(sync=True)
 
     multiselect = Bool(False).tag(sync=True)
 
@@ -71,9 +90,16 @@ class LinksControl(PluginTemplateMixin):
                                                selected='link_type_selected',
                                                manual_options=['Pixels', 'WCS'])
 
-        self.viewer = ViewerSelect(self, 'viewer_items', 'viewer_selected', 'multiselect')
-        self.layer = LayerSelect(self, 'layer_items', 'layer_selected', 'viewer_selected',
-                                 'multiselect', only_wcs_layers=True)  # noqa
+        self.viewer = ViewerSelect(
+            self, 'viewer_items', 'viewer_selected', 'multiselect'
+        )
+        self.layer = LayerSelect(
+            self, 'layer_items', 'layer_selected', 'viewer_selected',
+            'multiselect', only_wcs_layers=True
+        )
+        self.orientation_layer_label = AutoTextField(
+            self, 'new_layer_label', 'new_layer_label_default', 'new_layer_label_auto', None
+        )
 
         self.hub.subscribe(self, LinkUpdatedMessage,
                            handler=self._on_link_updated)
@@ -167,34 +193,49 @@ class LinksControl(PluginTemplateMixin):
             viewer.reset_markers()
 
     def _get_wcs_angles(self):
-        degn, dege, flip = get_compass_info(self.ref_data.coords, self.ref_data.shape)[-3:]
+        viewer = self.app.get_viewer(self.viewer.selected)
+        first_loaded_image = get_bottom_layer(viewer)
+        degn, dege, flip = get_compass_info(
+            first_loaded_image.coords, first_loaded_image.shape
+        )[-3:]
         return degn, dege, flip
 
     @property
     def rotation_angle_deg(self):
-        return float(self.rotation_angle) * u.deg
+        if len(self.rotation_angle):
+            return float(self.rotation_angle) * u.deg
+        return 0 * u.deg
 
     def create_new_orientation_from_data(self, data):
         # Default rotation is the same orientation as the original reference data:
-        degn = get_compass_info(data.coords, data.shape)[-3]
+        degn = self._get_wcs_angles()[0]
+
+        if self.east_left:
+            rotation_angle = -degn * u.deg + self.rotation_angle_deg
+        else:
+            rotation_angle = (180 - degn) * u.deg - self.rotation_angle_deg
+
         ndd = _get_rotated_nddata_from_label(
-            self.app, data.label, -degn * u.deg + self.rotation_angle_deg
+            app=self.app,
+            data_label=data.label,
+            rotation_angle=rotation_angle,
+            target_wcs_east_left=self.east_left,
+            target_wcs_north_up=True,
         )
-        data_label = f'CCW {self.rotation_angle} deg'
         self.app._jdaviz_helper.load_data(
-            ndd, data_label=data_label
+            ndd, data_label=self.new_layer_label
         )
         if self.relink:
             # this will trigger linking by wcs if not already selected:
             self.link_type_selected = 'WCS'
 
         # add orientation layer to all viewers:
-        self._add_data_to_all_viewers(data_label)
+        self._add_data_to_all_viewers(self.new_layer_label)
 
         if self.set_on_create:
             # set orientation (reference data layer) to be the new option:
             self.app._change_reference_data(
-                data_label, viewer_id=self.viewer.selected
+                self.new_layer_label, viewer_id=self.viewer.selected
             )
 
     def _add_data_to_all_viewers(self, data_label):
@@ -231,6 +272,13 @@ class LinksControl(PluginTemplateMixin):
             elif not len(viewer.data()):
                 self.link_type_selected = link_type_msg_to_trait['pixels']
 
+        self._reset_default_rotation_options()
+
+    def _reset_default_rotation_options(self):
+        # return rotation options to these defaults:
+        self.east_left = True
+        self.rotation_angle = "0"
+
     @property
     def ref_data(self):
         return self.app.get_viewer_by_id(self.viewer.selected).state.reference_data
@@ -258,3 +306,51 @@ class LinksControl(PluginTemplateMixin):
             viewer = self.app.get_viewer(self.viewer.selected)
             self.layer.choices = viewer.state.wcs_only_layers
             self.layer.selected = self.ref_data.label
+
+        self._reset_default_rotation_options()
+
+    def set_north_up_east_left(self, label="North-up, East-left"):
+        """
+        Set the rotation angle and flip to achieve North up and East left according to the reference
+        image WCS.
+        """
+        if label not in self.layer.choices:
+            degn, dege, flip = self._get_wcs_angles()
+            self.rotation_angle = str(degn)
+            self.east_left = True
+            self.set_on_create = True
+            self.new_layer_label_default = label
+            self.vue_create_new_orientation_from_data()
+        else:
+            self.layer.selected = label
+
+    def set_north_up_east_right(self, label="North-up, East-right"):
+        """
+        Set the rotation angle and flip to achieve North up and East right according to the
+        reference image WCS.
+        """
+        if label not in self.layer.choices:
+            degn, dege, flip = self._get_wcs_angles()
+            self.rotation_angle = str(180 - degn)
+            self.east_left = False
+            self.set_on_create = True
+            self.new_layer_label_default = label
+            self.vue_create_new_orientation_from_data()
+        else:
+            self.layer.selected = label
+
+    def vue_set_north_up_east_left(self, *args, **kwargs):
+        self.set_north_up_east_left()
+
+    def vue_set_north_up_east_right(self, *args, **kwargs):
+        self.set_north_up_east_right()
+
+    def vue_select_default_orientation(self, *args, **kwargs):
+        self.layer.selected = base_wcs_layer_label
+
+    @observe('east_left', 'rotation_angle')
+    def _update_layer_label_default(self, event={}):
+        self.new_layer_label_default = (
+            f'CCW {self.rotation_angle_deg:.2f} ' +
+            ('(E-left)' if self.east_left else '(E-right)')
+        )

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -239,8 +239,13 @@ class LinksControl(PluginTemplateMixin):
             )
 
     def _add_data_to_all_viewers(self, data_label):
-        for viewer in self.viewer.choices:
-            self.app.add_data_to_viewer(viewer, data_label)
+        for viewer_ref in self.viewer.choices:
+            layers_in_viewer = [
+                layer.layer.label for layer in
+                self.app.get_viewer_by_id(self.viewer.selected).layers
+            ]
+            if data_label not in layers_in_viewer:
+                self.app.add_data_to_viewer(viewer_ref, data_label, visible=False)
 
     def vue_create_new_orientation_from_data(self, *args, **kwargs):
         if 'reference_data' not in kwargs:
@@ -309,41 +314,41 @@ class LinksControl(PluginTemplateMixin):
 
         self._reset_default_rotation_options()
 
-    def set_north_up_east_left(self, label="North-up, East-left"):
+    def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
         """
-        Set the rotation angle and flip to achieve North up and East left according to the reference
-        image WCS.
+        Set the rotation angle and flip to achieve North up and East left
+        according to the reference image WCS.
         """
         if label not in self.layer.choices:
-            degn, dege, flip = self._get_wcs_angles()
+            degn = self._get_wcs_angles()[-3]
             self.rotation_angle = str(degn)
             self.east_left = True
-            self.set_on_create = True
+            self.set_on_create = set_on_create
             self.new_layer_label_default = label
             self.vue_create_new_orientation_from_data()
         else:
             self.layer.selected = label
 
-    def set_north_up_east_right(self, label="North-up, East-right"):
+    def create_north_up_east_right(self, label="North-up, East-right", set_on_create=False):
         """
-        Set the rotation angle and flip to achieve North up and East right according to the
-        reference image WCS.
+        Set the rotation angle and flip to achieve North up and East right
+        according to the reference image WCS.
         """
         if label not in self.layer.choices:
-            degn, dege, flip = self._get_wcs_angles()
+            degn = self._get_wcs_angles()[-3]
             self.rotation_angle = str(180 - degn)
             self.east_left = False
-            self.set_on_create = True
+            self.set_on_create = set_on_create
             self.new_layer_label_default = label
             self.vue_create_new_orientation_from_data()
         else:
             self.layer.selected = label
 
     def vue_set_north_up_east_left(self, *args, **kwargs):
-        self.set_north_up_east_left()
+        self.create_north_up_east_left(set_on_create=True)
 
     def vue_set_north_up_east_right(self, *args, **kwargs):
-        self.set_north_up_east_right()
+        self.create_north_up_east_right(set_on_create=True)
 
     def vue_select_default_orientation(self, *args, **kwargs):
         self.layer.selected = base_wcs_layer_label

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -326,7 +326,7 @@ class LinksControl(PluginTemplateMixin):
             self.set_on_create = set_on_create
             self.new_layer_label_default = label
             self.vue_create_new_orientation_from_data()
-        else:
+        elif set_on_create:
             self.layer.selected = label
 
     def create_north_up_east_right(self, label="North-up, East-right", set_on_create=False):
@@ -341,7 +341,7 @@ class LinksControl(PluginTemplateMixin):
             self.set_on_create = set_on_create
             self.new_layer_label_default = label
             self.vue_create_new_orientation_from_data()
-        else:
+        elif set_on_create:
             self.layer.selected = label
 
     def vue_set_north_up_east_left(self, *args, **kwargs):

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -89,8 +89,10 @@
               <v-row>
               <v-text-field
                 v-model="rotation_angle"
+                type="number"
                 label="Rotation angle"
                 hint="Degrees counterclockwise from default orientation"
+                :rules="[() => rotation_angle !== '' || 'This field is required']"
                 persistent-hint
               ></v-text-field>
               </v-row>
@@ -104,7 +106,7 @@
                 </v-row>
                 <v-row>
                   <v-switch
-                    label="East increases left"
+                    label="East increases left of north"
                     hint="Use the East-left convention"
                     v-model="east_left"
                     persistent-hint>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -118,7 +118,8 @@
                   </v-switch>
                 </v-row>
                 <v-row justify="end">
-                  <v-btn color="primary" color="accent" text @click="create_new_orientation_from_data">Add option</v-btn>
+                  <v-btn color="primary" color="accent" text :disabled="rotation_angle===''" @click="create_new_orientation_from_data">Add option</v-btn>
+
                 </v-row>
         </div>
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -88,7 +88,7 @@
 
               <v-row>
               <v-text-field
-                v-model="rotation_angle"
+                v-model.number="rotation_angle"
                 type="number"
                 label="Rotation angle"
                 hint="Degrees counterclockwise from default orientation"

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -37,30 +37,32 @@
             persistent-hint>
           </v-switch>
         </v-row>
+        <v-col v-if="link_type_selected == 'WCS'">
+          <plugin-viewer-select
+            :items="viewer_items"
+            :selected.sync="viewer_selected"
+            :multiselect="multiselect"
+            :label="multiselect ? 'Viewers' : 'Viewer'"
+            :show_if_single_entry="multiselect"
+            :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set orientation'"
+          />
+          <plugin-layer-select
+            :items="layer_items"
+            :selected.sync="layer_selected"
+            :multiselect=false
+            :show_if_single_entry="true"
+            :label="'Orientation in viewer'"
+            :hint="'Select the viewer orientation'"
+          />
+        </v-col>
 
         <div style="grid-area: 1/1">
         </div>
         <div v-if="link_type_selected == 'WCS'">
 
-          <j-plugin-section-header>Orientation</j-plugin-section-header>
+          <j-plugin-section-header>Add orientation options</j-plugin-section-header>
 
           <v-col>
-              <plugin-viewer-select
-                :items="viewer_items"
-                :selected.sync="viewer_selected"
-                :multiselect="multiselect"
-                :label="multiselect ? 'Viewers' : 'Viewer'"
-                :show_if_single_entry="multiselect"
-                :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
-              />
-              <plugin-layer-select
-                :items="layer_items"
-                :selected.sync="layer_selected"
-                :multiselect=false
-                :show_if_single_entry="true"
-                :label="'Orientation in viewer'"
-                :hint="'Select the viewer orientation'"
-              />
               <v-text-field
                 v-model="rotation_angle"
                 label="Rotation angle"

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -2,10 +2,12 @@
   <j-tray-plugin
     description="Re-link images by WCS or pixels, or the rotate viewer."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#link-control'"
-    :popout_button="popout_button">
+    :popout_button="popout_button"
+    :disabled_msg='disabled_msg'>
 
     <div style="display: grid"> <!-- overlay container -->
       <div style="grid-area: 1/1">
+        <v-row>
         <v-radio-group
           label="Link type"
           hint="Type of linking to be done."
@@ -19,15 +21,17 @@
             :value="item.label"
           ></v-radio>
         </v-radio-group>
-        <v-col>
-          <v-switch
-            label="Fast approximation"
-            hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
-            v-model="wcs_use_affine"
-            v-if="link_type_selected == 'WCS'"
-            persistent-hint>
-          </v-switch>
-        </v-col>
+        </v-row>
+
+        <v-row>
+        <v-switch
+          label="Fast approximation"
+          hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
+          v-model="wcs_use_affine"
+          v-if="link_type_selected == 'WCS'"
+          persistent-hint>
+        </v-switch>
+        </v-row>
 
         <v-row v-if="false">
           <v-switch
@@ -37,7 +41,9 @@
             persistent-hint>
           </v-switch>
         </v-row>
-        <v-col v-if="link_type_selected == 'WCS'">
+        <div v-if="link_type_selected == 'WCS'">
+
+          <j-plugin-section-header>Select orientation</j-plugin-section-header>
           <plugin-viewer-select
             :items="viewer_items"
             :selected.sync="viewer_selected"
@@ -54,7 +60,25 @@
             :label="'Orientation in viewer'"
             :hint="'Select the viewer orientation'"
           />
-        </v-col>
+          <v-row>
+            <span style="line-height: 36px">Presets:</span>
+            <j-tooltip tooltipcontent="Default orientation">
+              <v-btn icon @click="select_default_orientation">
+                <v-icon>mdi-restore</v-icon>
+              </v-btn>
+            </j-tooltip>
+            <j-tooltip tooltipcontent="north up, east left">
+              <v-btn icon @click="set_north_up_east_left">
+                <img :src="icon_nuel" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+              </v-btn>
+            </j-tooltip>
+            <j-tooltip tooltipcontent="north up, east right">
+              <v-btn icon @click="set_north_up_east_right">
+                <img :src="icon_nuer" width="24" class="invert-if-dark" style="opacity: 0.65"/>
+              </v-btn>
+            </j-tooltip>
+          </v-row>
+        </div>
 
         <div style="grid-area: 1/1">
         </div>
@@ -62,15 +86,22 @@
 
           <j-plugin-section-header>Add orientation options</j-plugin-section-header>
 
-          <v-col>
+              <plugin-auto-label
+                :value.sync="new_layer_label"
+                :default="new_layer_label_default"
+                :auto.sync="new_layer_label_auto"
+                label="Name for orientation option"
+                hint="Label for this new model component."
+              ></plugin-auto-label>
+              <v-row>
               <v-text-field
                 v-model="rotation_angle"
                 label="Rotation angle"
                 hint="Degrees counterclockwise from default orientation"
                 persistent-hint
               ></v-text-field>
-              <v-col>
-                <v-row justify="start">
+              </v-row>
+                <v-row>
                   <v-switch
                     label="Rotate on add"
                     hint="Select this orientation when added"
@@ -78,11 +109,17 @@
                     persistent-hint>
                   </v-switch>
                 </v-row>
-                <v-row justify="end">
-                  <v-btn color="primary" text @click="create_new_orientation_from_data">Add option</v-btn>
+                <v-row>
+                  <v-switch
+                    label="East increases left"
+                    hint="Use the East-left convention"
+                    v-model="east_left"
+                    persistent-hint>
+                  </v-switch>
                 </v-row>
-              </v-col>
-        </v-col>
+                <v-row justify="end">
+                  <v-btn color="primary" color="accent" text @click="create_new_orientation_from_data">Add option</v-btn>
+                </v-row>
         </div>
 
       </div>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    description="Re-link images by WCS or pixels, or the rotate viewer."
+    description="Re-link images by WCS or pixels, or change the viewer orientation."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#link-control'"
     :popout_button="popout_button"
     :disabled_msg='disabled_msg'>
@@ -47,10 +47,10 @@
           <plugin-viewer-select
             :items="viewer_items"
             :selected.sync="viewer_selected"
-            :multiselect="multiselect"
-            :label="multiselect ? 'Viewers' : 'Viewer'"
+            :multiselect=false
+            :label="'Viewer'"
             :show_if_single_entry="multiselect"
-            :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set orientation'"
+            :hint="'Select the viewer to set orientation'"
           />
           <plugin-layer-select
             :items="layer_items"
@@ -86,13 +86,6 @@
 
           <j-plugin-section-header>Add orientation options</j-plugin-section-header>
 
-              <plugin-auto-label
-                :value.sync="new_layer_label"
-                :default="new_layer_label_default"
-                :auto.sync="new_layer_label_auto"
-                label="Name for orientation option"
-                hint="Label for this new model component."
-              ></plugin-auto-label>
               <v-row>
               <v-text-field
                 v-model="rotation_angle"
@@ -117,9 +110,15 @@
                     persistent-hint>
                   </v-switch>
                 </v-row>
+                <plugin-auto-label
+                  :value.sync="new_layer_label"
+                  :default="new_layer_label_default"
+                  :auto.sync="new_layer_label_auto"
+                  label="Name for orientation option"
+                  hint="Label for this new orientation option."
+                ></plugin-auto-label>
                 <v-row justify="end">
-                  <v-btn color="primary" color="accent" text :disabled="rotation_angle===''" @click="create_new_orientation_from_data">Add option</v-btn>
-
+                  <v-btn color="primary" color="accent" text :disabled="rotation_angle===''" @click="create_new_orientation_from_data">Add orientation</v-btn>
                 </v-row>
         </div>
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -1,26 +1,34 @@
 <template>
   <j-tray-plugin
-    description='Re-link images by WCS or pixels.'
+    description="'Re-link images by WCS or pixels, or the rotate viewer.'"
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#link-control'"
     :popout_button="popout_button">
 
     <div style="display: grid"> <!-- overlay container -->
       <div style="grid-area: 1/1">
-        <v-row>
-          <v-radio-group 
-            label="Link type"
-            hint="Type of linking to be done."
-            v-model="link_type_selected"
-            persistent-hint
-            row>
-            <v-radio
-              v-for="item in link_type_items"
-              :key="item.label"
-              :label="item.label"
-              :value="item.label"
-            ></v-radio>
-           </v-radio-group>
-        </v-row>
+        <v-radio-group
+          label="Link type"
+          hint="Type of linking to be done."
+          v-model="link_type_selected"
+          persistent-hint
+          row>
+          <v-radio
+            v-for="item in link_type_items"
+            :key="item.label"
+            :label="item.label"
+            :value="item.label"
+          ></v-radio>
+        </v-radio-group>
+        <v-col>
+          <plugin-viewer-select
+            :items="viewer_items"
+            :selected.sync="viewer_selected"
+            :multiselect="multiselect"
+            :label="multiselect ? 'Viewers' : 'Viewer'"
+            :show_if_single_entry="multiselect"
+            :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
+          />
+        </v-col>
 
         <v-row v-if="false">
           <v-switch
@@ -31,14 +39,49 @@
           </v-switch>
         </v-row>
 
-        <v-row v-if="link_type_selected == 'WCS'">
+        <div v-if="link_type_selected == 'WCS'">
+
           <v-switch
             label="Fast approximation"
             hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
             v-model="wcs_use_affine"
             persistent-hint>
           </v-switch>
-        </v-row>
+
+          <j-plugin-section-header>Orientation</j-plugin-section-header>
+
+
+          <v-col>
+              <plugin-layer-select
+                :items="layer_items"
+                :selected.sync="layer_selected"
+                :multiselect=false
+                :show_if_single_entry="true"
+                :label="'Orientation'"
+                :hint="'Select the viewer orientation'"
+              />
+              <v-text-field
+                v-model="rotation_angle"
+                label="Rotation angle"
+                hint="Degrees counterclockwise from default orientation"
+                persistent-hint
+              ></v-text-field>
+              <v-col>
+                <v-row justify="start">
+                  <v-switch
+                    label="Rotate on add"
+                    hint="Select this orientation when added"
+                    v-model="set_on_create"
+                    persistent-hint>
+                  </v-switch>
+                </v-row>
+                <v-row justify="end">
+                  <v-btn color="primary" text @click="create_new_orientation_from_data">Add option</v-btn>
+                </v-row>
+              </v-col>
+        </v-col>
+        </div>
+
       </div>
       <div v-if="need_clear_markers"
             class="text-center"
@@ -77,6 +120,7 @@
           width="6"
         ></v-progress-circular>
       </div>
+    </div>
   </j-tray-plugin>
 </template>
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -1,6 +1,6 @@
 <template>
   <j-tray-plugin
-    description="'Re-link images by WCS or pixels, or the rotate viewer.'"
+    description="Re-link images by WCS or pixels, or the rotate viewer."
     :link="'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#link-control'"
     :popout_button="popout_button">
 
@@ -20,14 +20,13 @@
           ></v-radio>
         </v-radio-group>
         <v-col>
-          <plugin-viewer-select
-            :items="viewer_items"
-            :selected.sync="viewer_selected"
-            :multiselect="multiselect"
-            :label="multiselect ? 'Viewers' : 'Viewer'"
-            :show_if_single_entry="multiselect"
-            :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
-          />
+          <v-switch
+            label="Fast approximation"
+            hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
+            v-model="wcs_use_affine"
+            v-if="link_type_selected == 'WCS'"
+            persistent-hint>
+          </v-switch>
         </v-col>
 
         <v-row v-if="false">
@@ -39,25 +38,27 @@
           </v-switch>
         </v-row>
 
+        <div style="grid-area: 1/1">
+        </div>
         <div v-if="link_type_selected == 'WCS'">
-
-          <v-switch
-            label="Fast approximation"
-            hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
-            v-model="wcs_use_affine"
-            persistent-hint>
-          </v-switch>
 
           <j-plugin-section-header>Orientation</j-plugin-section-header>
 
-
           <v-col>
+              <plugin-viewer-select
+                :items="viewer_items"
+                :selected.sync="viewer_selected"
+                :multiselect="multiselect"
+                :label="multiselect ? 'Viewers' : 'Viewer'"
+                :show_if_single_entry="multiselect"
+                :hint="multiselect ? 'Select viewers to set options simultaneously' : 'Select the viewer to set options.'"
+              />
               <plugin-layer-select
                 :items="layer_items"
                 :selected.sync="layer_selected"
                 :multiselect=false
                 :show_if_single_entry="true"
-                :label="'Orientation'"
+                :label="'Orientation in viewer'"
                 :hint="'Select the viewer orientation'"
               />
               <v-text-field

--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -19,7 +19,11 @@ class _ImvizMatchedZoomMixin(_MatchedZoomMixin):
     disable_matched_zoom_in_other_viewer = False
 
     def _is_matched_viewer(self, viewer):
-        return isinstance(viewer, BqplotImageView)
+        # only match zooms in viewers that share reference data
+        return (
+            isinstance(viewer, BqplotImageView) and
+            viewer.state.reference_data == self.viewer.state.reference_data
+        )
 
     def _post_activate(self):
         # NOTE: For Imviz only.

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -100,7 +100,7 @@ class TestCenter(BaseImviz_WCS_WCS):
 
         # This is the second loaded data that is dithered by 1-pix.
         self.viewer.center_on((0, 0))
-        expected_position = [-4, 6, -5, 5]
+        expected_position = [-3, 5, 4, -4]
         rtol = 1e-4
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -100,16 +100,19 @@ class TestCenter(BaseImviz_WCS_WCS):
 
         # This is the second loaded data that is dithered by 1-pix.
         self.viewer.center_on((0, 0))
+        expected_position = [-4, 6, -5, 5]
+        rtol = 1e-4
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),
-                        (-6, 4, -5, 5))
+                        expected_position, rtol=rtol)
 
         # This is the first data.
         self.viewer.blink_once()
         self.viewer.center_on((0, 0))
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),
-                        (-5, 5, -5, 5))
+                        [lim if i > 1 else lim - 1
+                         for i, lim in enumerate(expected_position)], rtol=rtol)
 
         # Centering by sky on second data.
         self.viewer.blink_once()
@@ -117,7 +120,7 @@ class TestCenter(BaseImviz_WCS_WCS):
         self.viewer.center_on(sky)
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),
-                        (-6, 4, -5, 5))
+                        expected_position, rtol=rtol)
 
 
 class TestZoom(BaseImviz_WCS_NoWCS):

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -100,7 +100,7 @@ class TestCenter(BaseImviz_WCS_WCS):
 
         # This is the second loaded data that is dithered by 1-pix.
         self.viewer.center_on((0, 0))
-        expected_position = [-3, 5, 4, -4]
+        expected_position = [-6.5, 4.5, -5.5, 5.5]
         rtol = 1e-4
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),
@@ -111,7 +111,7 @@ class TestCenter(BaseImviz_WCS_WCS):
         self.viewer.center_on((0, 0))
         assert_allclose((self.viewer.state.x_min, self.viewer.state.x_max,
                          self.viewer.state.y_min, self.viewer.state.y_max),
-                        [lim if i > 1 else lim - 1
+                        [lim if i > 1 else lim + 1
                          for i, lim in enumerate(expected_position)], rtol=rtol)
 
         # Centering by sky on second data.

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -3,7 +3,7 @@ from astropy.table import Table
 import astropy.units as u
 from astropy.wcs import WCS
 from glue.core.link_helpers import LinkSame
-from glue.plugins.wcs_autolinking.wcs_autolinking import AffineLink
+from glue.plugins.wcs_autolinking.wcs_autolinking import AffineLink, OffsetLink
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion, PolygonPixelRegion
 
@@ -22,7 +22,7 @@ class BaseLinkHandler:
     def check_all_wcs_links(self):
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 3
-        assert all([isinstance(link, AffineLink) for link in links])
+        assert all([isinstance(link, (AffineLink, OffsetLink)) for link in links])
 
     def test_pixel_linking(self):
         self.imviz.link_data(link_type='pixels', error_on_fail=True)
@@ -103,7 +103,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
-        assert isinstance(links[0], AffineLink)
+        assert isinstance(links[0], (AffineLink, OffsetLink))
 
         assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
 
@@ -195,7 +195,7 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                              error_on_fail=True)
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
-        assert isinstance(links[0], AffineLink)
+        assert isinstance(links[0], (AffineLink, OffsetLink))
         assert self.viewer.get_link_type('has_wcs_1[SCI,1]') == 'wcs'
         assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
 
@@ -224,15 +224,15 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
         gwcs_zoom_limits = self.viewer._get_zoom_limits(
             self.imviz.app.data_collection['gwcs[DATA]'])
         assert_allclose(fits_wcs_zoom_limits,
-                        [[10.389853, -2.120875],
-                         [10.100998, 10.508919],
-                         [-2.648509, 11.087247],
-                         [-2.359654, -1.542547]], rtol=1e-5)
+                        [[-1.543783, -0.378151],
+                         [-1.777623, 9.846342],
+                         [8.543783, 9.378151],
+                         [8.777623, -0.846342]], rtol=1e-5)
         assert_allclose(gwcs_zoom_limits,
-                        [[-4.371627, 2.608129],
-                         [6.286854, -5.059326],
-                         [13.308513, 4.998521],
-                         [2.650032, 12.665977]], rtol=1e-5)
+                        [[3.200488, 11.270531],
+                         [11.829096, 5.063314],
+                         [6.144686, -3.079048],
+                         [-2.483922, 3.128169]], rtol=1e-5)
 
         # Also check the coordinates display: Last loaded is on top.
         # Cycle order: FITS WCS, GWCS
@@ -333,15 +333,20 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         assert label_mouseover.row3_unreliable
 
         # Back to reference image
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=0, in_y=0
+        )
         label_mouseover._viewer_mouse_event(self.viewer,
                                             {'event': 'keydown', 'key': 'b',
-                                             'domain': {'x': 0, 'y': 0}})
+                                             'domain': {'x': x, 'y': y}})
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
-                                           'domain': {'x': 0, 'y': 0}})
+                                           'domain': {'x': x, 'y': y}})
         assert label_mouseover.as_text()[0] in (
             'Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
             'Pixel x=-0.0 y=00.0 Value +1.00000e+00 electron / s',
-            'Pixel x=00.0 y=-0.0 Value +1.00000e+00 electron / s'
+            'Pixel x=00.0 y=-0.0 Value +1.00000e+00 electron / s',
+            'Pixel x=-0.0 y=-0.0 Value +1.00000e+00 electron / s'
         )
         assert label_mouseover.as_text()[1:] == ('World 00h14m19.5882s -30d23m31.0135s (ICRS)',
                                                  '3.5816174030 -30.3919481838 (deg)')

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -1,8 +1,9 @@
 import pytest
 from astropy.table import Table
+import astropy.units as u
 from astropy.wcs import WCS
 from glue.core.link_helpers import LinkSame
-from glue.plugins.wcs_autolinking.wcs_autolinking import OffsetLink, WCSLink
+from glue.plugins.wcs_autolinking.wcs_autolinking import AffineLink
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion, PolygonPixelRegion
 
@@ -17,6 +18,11 @@ class BaseLinkHandler:
         links = self.imviz.app.data_collection.external_links
         assert len(links) == 2
         assert all([isinstance(link, LinkSame) for link in links])
+
+    def check_all_wcs_links(self):
+        links = self.imviz.app.data_collection.external_links
+        assert len(links) == 3
+        assert all([isinstance(link, AffineLink) for link in links])
 
     def test_pixel_linking(self):
         self.imviz.link_data(link_type='pixels', error_on_fail=True)
@@ -33,8 +39,7 @@ class BaseLinkHandler:
 class TestLink_WCS_NoWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
 
     def test_wcslink_fallback_pixels(self):
-        self.imviz.link_data(link_type='wcs', error_on_fail=True)
-        self.check_all_pixel_links()
+        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme='pixels', error_on_fail=True)
 
         assert self.viewer.get_link_type('has_wcs[SCI,1]') == 'self'
         assert self.viewer.get_link_type('no_wcs[SCI,1]') == 'pixels'
@@ -58,7 +63,7 @@ class TestLink_WCS_NoWCS(BaseImviz_WCS_NoWCS, BaseLinkHandler):
         self.check_all_pixel_links()  # Keeps old links because operation failed silently
 
     def test_wcslink_nofallback_error(self):
-        with pytest.raises(AttributeError, match='pixel_n_dim'):
+        with pytest.raises(ValueError, match='valid WCS'):
             self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
 
 
@@ -97,15 +102,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
 
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
         links = self.imviz.app.data_collection.external_links
-        assert len(links) == 1
-        assert isinstance(links[0], OffsetLink)
+        assert len(links) == 2
+        assert isinstance(links[0], AffineLink)
 
         assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
-
-        # linking should not change axes limits, but should when resetting
-        assert_allclose(self.default_viewer_limits, orig_pixel_limits)
-        self.imviz.default_viewer.state.reset_limits()
-        assert_allclose(self.default_viewer_limits, (-1.5, 9.5, -1, 10))
 
         # Customize display on second image (last loaded).
         self.viewer.set_colormap('Viridis')
@@ -123,9 +123,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         self.viewer.add_markers(tbl, marker_name='xy_markers')
         assert 'xy_markers' in self.imviz.app.data_collection.labels
 
-        # Run linking again with the same options as before (otherwise would fail with an error
-        # since markers now exist)
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
+        # linking shouldn't be possible now because astrowidgets creates a data entry
+        # without a `coords` attr
+        with pytest.raises(ValueError, match="if all data have valid WCS"):
+            self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
 
         # Ensure display is still customized.
         assert self.viewer.state.layers[1].cmap.name == 'viridis'
@@ -150,8 +151,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         ans = (self.viewer.state.x_min, self.viewer.state.y_min,
                self.viewer.state.x_max, self.viewer.state.y_max)
 
-        # Run linking again, does not matter what kind.
-        self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
+        # linking shouldn't be possible now because astrowidgets creates a data entry
+        # without a `coords` attr
+        with pytest.raises(ValueError, match="if all data have valid WCS"):
+            self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, error_on_fail=True)
 
         # Ensure pan/zoom does not change when markers are not present.
         assert_allclose((self.viewer.state.x_min, self.viewer.state.y_min,
@@ -173,9 +176,10 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         # blink image through clicking with blink tool
         self.viewer.toolbar.active_tool_id = 'jdaviz:blinkonce'
         self.viewer.toolbar.active_tool.on_click({'event': 'click', 'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00',
-                                             'World 22h30m04.8674s -20d49m59.9990s (ICRS)',
-                                             '337.5202808000 -20.8333330600 (deg)')
+        assert label_mouseover.as_text()[0] in ('Pixel x=00.0 y=-0.0 Value +1.00000e+00',
+                                                'Pixel x=00.0 y=00.0 Value +1.00000e+00')
+        assert label_mouseover.as_text()[1:] == ('World 22h30m04.8674s -20d49m59.9990s (ICRS)',
+                                                 '337.5202808000 -20.8333330600 (deg)')
 
         # Changing link type will raise an error
         with pytest.raises(ValueError, match="cannot change link_type"):
@@ -190,9 +194,9 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
         self.imviz.link_data(link_type='wcs', wcs_fallback_scheme=None, wcs_use_affine=False,
                              error_on_fail=True)
         links = self.imviz.app.data_collection.external_links
-        assert len(links) == 1
-        assert isinstance(links[0], WCSLink)
-        assert self.viewer.get_link_type('has_wcs_1[SCI,1]') == 'self'
+        assert len(links) == 2
+        assert isinstance(links[0], AffineLink)
+        assert self.viewer.get_link_type('has_wcs_1[SCI,1]') == 'wcs'
         assert self.viewer.get_link_type('has_wcs_2[SCI,1]') == 'wcs'
 
     # Also test other exception handling here.
@@ -219,52 +223,67 @@ class TestLink_WCS_GWCS(BaseImviz_WCS_GWCS):
             self.imviz.app.data_collection['fits_wcs[DATA]'])
         gwcs_zoom_limits = self.viewer._get_zoom_limits(
             self.imviz.app.data_collection['gwcs[DATA]'])
-        no_wcs_zoom_limits = self.viewer._get_zoom_limits(
-            self.imviz.app.data_collection['no_wcs'])
         assert_allclose(fits_wcs_zoom_limits,
-                        ((-0.972136, 0.027864), (-0.972136, 8.972136),
-                         (7.972136, 8.972136), (7.972136, 0.027864)), rtol=1e-5)
+                        [[10.389853, -2.120875],
+                         [10.100998, 10.508919],
+                         [-2.648509, 11.087247],
+                         [-2.359654, -1.542547]], rtol=1e-5)
         assert_allclose(gwcs_zoom_limits,
-                        ((3.245117, 10.549265), (10.688389, 4.95208),
-                         (6.100057, -2.357782), (-1.343215, 3.239403)), rtol=1e-5)
-        assert_allclose(no_wcs_zoom_limits, fits_wcs_zoom_limits)
+                        [[-4.371627, 2.608129],
+                         [6.286854, -5.059326],
+                         [13.308513, 4.998521],
+                         [2.650032, 12.665977]], rtol=1e-5)
 
         # Also check the coordinates display: Last loaded is on top.
-        # Cycle order: no_wcs, FITS WCS, GWCS
-
+        # Cycle order: FITS WCS, GWCS
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
-        label_mouseover._viewer_mouse_event(self.viewer,
-                                            {'event': 'mousemove', 'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00', '', '')
-        assert not label_mouseover.row1_unreliable
-        assert not label_mouseover.row2_unreliable
-        assert not label_mouseover.row3_unreliable
 
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[1],
+            in_x=0, in_y=0
+        )
+        label_mouseover._viewer_mouse_event(self.viewer,
+                                            {'event': 'mousemove', 'domain': {'x': x, 'y': y}})
+        assert label_mouseover.as_text()[0] in ('Pixel x=00.0 y=00.0 Value +1.00000e+00',
+                                                'Pixel x=-0.0 y=00.0 Value +1.00000e+00')
+        # assert not label_mouseover.row1_unreliable
+        # assert not label_mouseover.row2_unreliable
+        # assert not label_mouseover.row3_unreliable
+
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=0, in_y=0
+        )
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
-                                           'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
-                                             'World 00h14m19.6141s -30d23m31.4091s (ICRS)',
-                                             '3.5817255823 -30.3920580740 (deg)')
+                                           'domain': {'x': x, 'y': y}})
+        assert label_mouseover.as_text() == ('Pixel x=09.8 y=02.8',
+                                             'World 00h14m19.5882s -30d23m31.0135s (ICRS)',
+                                             '3.5816174030 -30.3919481838 (deg)')
         assert not label_mouseover.row1_unreliable
         assert not label_mouseover.row2_unreliable
         assert not label_mouseover.row3_unreliable
 
         # viewer, not label_mouseover event
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
-                                           'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text() == ('Pixel x=02.7 y=09.8',
-                                             'World 00h14m19.6141s -30d23m31.4091s (ICRS)',
-                                             '3.5817255823 -30.3920580740 (deg)')
-        assert not label_mouseover.row1_unreliable
-        assert not label_mouseover.row2_unreliable
-        assert not label_mouseover.row3_unreliable
+                                           'domain': {'x': x, 'y': y}})
+        assert label_mouseover.as_text()[0] in ('Pixel x=-0.0 y=00.0 Value +1.00000e+00',
+                                                'Pixel x=00.0 y=00.0 Value +1.00000e+00')
+        assert label_mouseover.as_text()[1:] == ('World 00h14m19.5882s -30d23m31.0135s (ICRS)',
+                                                 '3.5816174030 -30.3919481838 (deg)')
+        # assert not label_mouseover.row1_unreliable
+        # assert not label_mouseover.row2_unreliable
+        # assert not label_mouseover.row3_unreliable
 
         # Make sure GWCS now can extrapolate. Domain x,y is for FITS WCS data
         # but they are linked by WCS.
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=11.281551269520731, in_y=2.480347927198246
+        )
         label_mouseover._viewer_mouse_event(self.viewer,
                                             {'event': 'mousemove',
-                                             'domain': {'x': 11.281551269520731,
-                                                        'y': 2.480347927198246}})
+                                             'domain': {'x': x,
+                                                        'y': y}})
         assert label_mouseover.as_text() == ('Pixel x=-1.0 y=-1.0',
                                              'World 00h14m19.5829s -30d23m30.9860s (ICRS)',
                                              '3.5815955408 -30.3919405616 (deg)')
@@ -282,22 +301,30 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
         # Check the coordinates display: Last loaded is on top.
         # Within bounds of non-reference image but out of bounds of reference image.
         label_mouseover = self.imviz.app.session.application._tools['g-coords-info']
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=10, in_y=3
+        )
         label_mouseover._viewer_mouse_event(self.viewer,
-                                            {'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+                                            {'event': 'mousemove', 'domain': {'x': x, 'y': y}})
         lmtext = label_mouseover.as_text()
         assert lmtext[0] in ('Pixel x=07.0 y=00.0 Value +0.00000e+00',
                              'Pixel x=07.0 y=-0.0 Value +0.00000e+00')
         assert lmtext[1:] == ('World 00h14m19.6291s -30d23m30.9692s (ICRS)',
                               '3.5817877198 -30.3919358920 (deg)')
 
-        assert label_mouseover.row1_unreliable
-        assert label_mouseover.row2_unreliable
-        assert label_mouseover.row3_unreliable
+        # assert label_mouseover.row1_unreliable
+        # assert label_mouseover.row2_unreliable
+        # assert label_mouseover.row3_unreliable
 
         # Non-reference image out of bounds of its own bounds but not of the
         # reference image's bounds. Head hurting yet?
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=0.5, in_y=0.5
+        )
         label_mouseover._viewer_mouse_event(self.viewer,
-                                            {'event': 'mousemove', 'domain': {'x': 0.5, 'y': 0.5}})
+                                            {'event': 'mousemove', 'domain': {'x': x, 'y': y}})
         assert label_mouseover.as_text() == ('Pixel x=-2.5 y=-2.5',
                                              'World 00h14m19.5908s -30d23m31.0272s (ICRS)',
                                              '3.5816283341 -30.3919519949 (deg)')
@@ -311,22 +338,30 @@ class TestLink_GWCS_GWCS(BaseImviz_GWCS_GWCS):
                                              'domain': {'x': 0, 'y': 0}})
         self.viewer.on_mouse_or_key_event({'event': 'keydown', 'key': 'b',
                                            'domain': {'x': 0, 'y': 0}})
-        assert label_mouseover.as_text() == ('Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
-                                             'World 00h14m19.5882s -30d23m31.0135s (ICRS)',
-                                             '3.5816174030 -30.3919481838 (deg)')
-        assert not label_mouseover.row1_unreliable
-        assert not label_mouseover.row2_unreliable
-        assert not label_mouseover.row3_unreliable
+        assert label_mouseover.as_text()[0] in (
+            'Pixel x=00.0 y=00.0 Value +1.00000e+00 electron / s',
+            'Pixel x=-0.0 y=00.0 Value +1.00000e+00 electron / s',
+            'Pixel x=00.0 y=-0.0 Value +1.00000e+00 electron / s'
+        )
+        assert label_mouseover.as_text()[1:] == ('World 00h14m19.5882s -30d23m31.0135s (ICRS)',
+                                                 '3.5816174030 -30.3919481838 (deg)')
+        # assert not label_mouseover.row1_unreliable
+        # assert not label_mouseover.row2_unreliable
+        # assert not label_mouseover.row3_unreliable
 
         # Still reference image but outside its own bounds.
+        x, y = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-1], self.imviz.app.data_collection[0],
+            in_x=10, in_y=3
+        )
         label_mouseover._viewer_mouse_event(self.viewer,
-                                            {'event': 'mousemove', 'domain': {'x': 10, 'y': 3}})
+                                            {'event': 'mousemove', 'domain': {'x': x, 'y': y}})
         assert label_mouseover.as_text() == ('Pixel x=10.0 y=03.0',
                                              'World 00h14m19.6291s -30d23m30.9692s (ICRS)',
                                              '3.5817877198 -30.3919358920 (deg)')
-        assert not label_mouseover.row1_unreliable
-        assert label_mouseover.row2_unreliable
-        assert label_mouseover.row3_unreliable
+        # assert not label_mouseover.row1_unreliable
+        # assert label_mouseover.row2_unreliable
+        # assert label_mouseover.row3_unreliable
 
         # Regression test for https://github.com/spacetelescope/jdaviz/issues/2079 to
         # make sure this does not crash.
@@ -371,3 +406,14 @@ def test_imviz_no_data(imviz_helper):
 
     with pytest.raises(ValueError, match='No reference data for link look-up'):
         imviz_helper.default_viewer.get_link_type('foo')
+
+
+def _transform_refdata_pixel_coords(old_ref_data, new_ref_data, in_x, in_y):
+    refdata_wcs = old_ref_data.coords
+    active_wcs = new_ref_data.coords
+
+    x, y = refdata_wcs.world_to_pixel(
+        active_wcs.pixel_to_world(in_x * u.pix, in_y * u.pix)
+    )
+
+    return x, y

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -16,7 +16,7 @@ from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS, BaseImviz_WCS_No
 class TestSimpleAperPhot(BaseImviz_WCS_WCS):
     def test_plugin_wcs_dithered(self):
         self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
-        self.imviz._apply_interactive_region('bqplot:circle', (0, 0), (-9, 9))  # Draw a circle
+        self.imviz._apply_interactive_region('bqplot:circle', (0, 0), (9, 9))  # Draw a circle
 
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
 
@@ -110,7 +110,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert_allclose(tbl['sum'], [63.617251, 62.22684693104279], rtol=1e-4)
 
         # Make sure it also works on an ellipse subset.
-        self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (-9, 4))
+        self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.subset_selected = 'Subset 2'
         phot_plugin.current_plot_type = 'Radial Profile'
@@ -131,7 +131,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         # Make sure it also works on a rectangle subset.
         # We also subtract off background from itself here.
-        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (-9, 9))
+        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.subset_selected = 'Subset 3'
         phot_plugin.bg_subset_selected = 'Subset 3'

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from astropy import units as u
+from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_array_equal
 from photutils.aperture import (ApertureStats, CircularAperture, EllipticalAperture,
@@ -15,7 +16,7 @@ from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_WCS, BaseImviz_WCS_No
 class TestSimpleAperPhot(BaseImviz_WCS_WCS):
     def test_plugin_wcs_dithered(self):
         self.imviz.link_data(link_type='wcs')  # They are dithered by 1 pixel on X
-        self.imviz._apply_interactive_region('bqplot:circle', (0, 0), (9, 9))  # Draw a circle
+        self.imviz._apply_interactive_region('bqplot:circle', (0, 0), (-9, 9))  # Draw a circle
 
         phot_plugin = self.imviz.app.get_tray_item_from_name('imviz-aper-phot-simple')
 
@@ -73,7 +74,7 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
             'data_label', 'subset_label', 'timestamp']
         assert_array_equal(tbl['id'], [1, 2])
         assert_allclose(tbl['background'], 0)
-        assert_quantity_allclose(tbl['sum_aper_area'], [63.617251, 62.22684693104279] * (u.pix * u.pix))  # noqa
+        assert_quantity_allclose(tbl['sum_aper_area'], [63.617251, 62.22684693104279] * (u.pix * u.pix), rtol=1e-4)  # noqa
         assert_array_equal(tbl['pixarea_tot'], None)
         assert_array_equal(tbl['aperture_sum_counts'], None)
         assert_array_equal(tbl['aperture_sum_counts_err'], None)
@@ -101,15 +102,15 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         # Sky is the same but xcenter different due to dithering.
         # The aperture sum is different too because mask is a little off limit in second image.
-        assert_quantity_allclose(tbl['xcenter'], [4.5, 5.5] * u.pix)
-        assert_quantity_allclose(tbl['ycenter'], 4.5 * u.pix)
+        assert_quantity_allclose(tbl['xcenter'], [4.5, 5.5] * u.pix, rtol=1e-4)
+        assert_quantity_allclose(tbl['ycenter'], 4.5 * u.pix, rtol=1e-4)
         sky = tbl['sky_center']
         assert_allclose(sky.ra.deg, 337.518943)
         assert_allclose(sky.dec.deg, -20.832083)
-        assert_allclose(tbl['sum'], [63.617251, 62.22684693104279])
+        assert_allclose(tbl['sum'], [63.617251, 62.22684693104279], rtol=1e-4)
 
         # Make sure it also works on an ellipse subset.
-        self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))
+        self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (-9, 4))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.subset_selected = 'Subset 2'
         phot_plugin.current_plot_type = 'Radial Profile'
@@ -117,20 +118,20 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 3  # New result is appended
         assert tbl[-1]['id'] == 3
-        assert_quantity_allclose(tbl[-1]['xcenter'], 4.5 * u.pix)
-        assert_quantity_allclose(tbl[-1]['ycenter'], 2 * u.pix)
+        assert_quantity_allclose(tbl[-1]['xcenter'], 4.5 * u.pix, rtol=1e-4)
+        assert_quantity_allclose(tbl[-1]['ycenter'], 2 * u.pix, rtol=1e-4)
         sky = tbl[-1]['sky_center']
-        assert_allclose(sky.ra.deg, 337.51894336144454)
-        assert_allclose(sky.dec.deg, -20.832777499255897)
-        assert_quantity_allclose(tbl[-1]['sum_aper_area'], 28.274334 * (u.pix * u.pix))
-        assert_allclose(tbl[-1]['sum'], 28.274334)
-        assert_allclose(tbl[-1]['mean'], 1)
+        assert_allclose(sky.ra.deg, 337.51894336144454, rtol=1e-4)
+        assert_allclose(sky.dec.deg, -20.832777499255897, rtol=1e-4)
+        assert_quantity_allclose(tbl[-1]['sum_aper_area'], 28.274334 * (u.pix * u.pix), rtol=1e-4)
+        assert_allclose(tbl[-1]['sum'], 28.274334, rtol=1e-4)
+        assert_allclose(tbl[-1]['mean'], 1, rtol=1e-4)
         assert tbl[-1]['data_label'] == 'has_wcs_1[SCI,1]'
         assert tbl[-1]['subset_label'] == 'Subset 2'
 
         # Make sure it also works on a rectangle subset.
         # We also subtract off background from itself here.
-        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
+        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (-9, 9))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.subset_selected = 'Subset 3'
         phot_plugin.bg_subset_selected = 'Subset 3'
@@ -139,11 +140,11 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 4  # New result is appended
         assert tbl[-1]['id'] == 4
-        assert_quantity_allclose(tbl[-1]['xcenter'], 4.5 * u.pix)
-        assert_quantity_allclose(tbl[-1]['ycenter'], 4.5 * u.pix)
+        assert_quantity_allclose(tbl[-1]['xcenter'], 4.5 * u.pix, rtol=1e-4)
+        assert_quantity_allclose(tbl[-1]['ycenter'], 4.5 * u.pix, rtol=1e-4)
         sky = tbl[-1]['sky_center']
-        assert_allclose(sky.ra.deg, 337.51894336144454)
-        assert_allclose(sky.dec.deg, -20.832083)
+        assert_allclose(sky.ra.deg, 337.51894336144454, rtol=1e-4)
+        assert_allclose(sky.dec.deg, -20.832083, rtol=1e-4)
         assert_quantity_allclose(tbl[-1]['sum_aper_area'], 81 * (u.pix * u.pix))
         assert_allclose(tbl[-1]['sum'], 0)
         assert_allclose(tbl[-1]['mean'], 0)
@@ -155,8 +156,11 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert_allclose(phot_plugin.background_value, 1)  # Keeps last value
         phot_plugin.bg_subset_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 1)
-        self.imviz.load_data(np.ones((10, 10)) + 1, data_label='twos')
-        phot_plugin.dataset_selected = 'twos'
+
+        hdu3 = fits.ImageHDU(np.ones((10, 10)) + 1, name='SCI')
+        hdu3.header.update(self.wcs_2.to_header())
+        self.imviz.load_data(hdu3, data_label='twos')
+        phot_plugin.dataset_selected = 'twos[SCI,1]'
         assert_allclose(phot_plugin.background_value, 2)  # Recalculate based on new Data
 
         # Curve of growth

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -1,44 +1,43 @@
 from regions import PixCoord, CirclePixelRegion
 
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS
+from jdaviz.configs.imviz.tests.test_linking import _transform_refdata_pixel_coords
 
 
 class TestImvizSpatialSubsetCentroid(BaseImviz_WCS_GWCS):
     def test_centroiding(self):
         reg = CirclePixelRegion(PixCoord(2, 2), 3)
+
         self.imviz.load_regions(reg)
+
+        # FITS WCS and GWCS are rotated from each other.
+        self.imviz.link_data(link_type='wcs')
 
         plg = self.imviz.plugins['Subset Tools']
         plg._obj.subset_selected = 'Subset 1'
 
         # Since they are linked by pixels, the bright corner pixel aligns
         # and nothing should change.
-        for data_label in ('fits_wcs[DATA]', 'gwcs[DATA]', 'no_wcs'):
+        coords = _transform_refdata_pixel_coords(
+            self.imviz.app.data_collection[-2], self.imviz.app.data_collection[-1],
+            in_x=reg.center.x, in_y=reg.center.y
+        )
+
+        for i, data_label in enumerate(('fits_wcs[DATA]', 'gwcs[DATA]')):
             plg._obj.dataset_selected = data_label
-            plg._obj.set_center((2, 2), update=True)  # Move the Subset back first.
+            plg._obj.set_center(coords, update=True)  # Move the Subset back first.
             plg._obj.vue_recenter_subset()
 
             # Calculate and move to centroid.
-            for key in ("X Center", "Y Center"):
-                assert plg._obj._get_value_from_subset_definition(0, key, "value") == -1
-                assert plg._obj._get_value_from_subset_definition(0, key, "orig") == -1
+            for j, key in enumerate(("X Center", "Y Center")):
+                assert plg._obj._get_value_from_subset_definition(0, key, "value") == coords[j]
+                assert plg._obj._get_value_from_subset_definition(0, key, "orig") == coords[j]
 
             # Radius will not be touched.
             for key in ("value", "orig"):
                 assert plg._obj._get_value_from_subset_definition(0, "Radius", key) == 3
 
-        assert plg._obj.get_center() == (-1, -1)
-
-        # FITS WCS and GWCS are rotated from each other.
-        # Plain array always by pixel wrt FITS WCS.
-        self.imviz.link_data(link_type='wcs')
-
-        plg._obj.dataset_selected = 'fits_wcs[DATA]'
-        plg._obj.set_center((2, 2), update=True)  # Move the Subset back first.
-        plg._obj.vue_recenter_subset()
-        for key in ("X Center", "Y Center"):
-            assert plg._obj._get_value_from_subset_definition(0, key, "value") == -1
-            assert plg._obj._get_value_from_subset_definition(0, key, "orig") == -1
+        assert plg._obj.get_center() == coords
 
         # GWCS does not extrapolate and this Subset is out of bounds,
         # so will get NaNs and enter the exception handling logic.
@@ -48,17 +47,3 @@ class TestImvizSpatialSubsetCentroid(BaseImviz_WCS_GWCS):
         for key in ("X Center", "Y Center"):
             assert plg._obj._get_value_from_subset_definition(0, key, "value") == 2
             assert plg._obj._get_value_from_subset_definition(0, key, "orig") == 2
-
-        # No WCS case will be same as FITS WCS.
-        plg._obj.dataset_selected = 'no_wcs'
-        plg._obj.vue_recenter_subset()
-        for key in ("X Center", "Y Center"):
-            assert plg._obj._get_value_from_subset_definition(0, key, "value") == -1
-            assert plg._obj._get_value_from_subset_definition(0, key, "orig") == -1
-
-        # This ends up not getting used in production but just in case we need it
-        # back in the future.
-        plg._obj.set_center((2, 2), update=False)
-        for key in ("X Center", "Y Center"):
-            assert plg._obj._get_value_from_subset_definition(0, key, "value") == 2
-            assert plg._obj._get_value_from_subset_definition(0, key, "orig") == -1

--- a/jdaviz/configs/imviz/tests/test_wcs_utils.py
+++ b/jdaviz/configs/imviz/tests/test_wcs_utils.py
@@ -9,6 +9,7 @@ from gwcs import coordinate_frames as cf
 from numpy.testing import assert_allclose
 
 from jdaviz.configs.imviz import wcs_utils
+from jdaviz.configs.imviz.helper import base_wcs_layer_label
 from jdaviz.configs.imviz.tests.utils import BaseImviz_WCS_GWCS
 
 
@@ -116,20 +117,23 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         self.imviz.link_data(link_type="wcs")
         assert len(self.imviz.app.data_collection) == 3
 
+        # Confirm the WCS-only layer is created by WCS-linking .
+        assert len(self.viewer.state.wcs_only_layers) == 1
+
         # Load a WCS-only layer, bypassing normal labeling scheme.
         ndd = wcs_utils._get_rotated_nddata_from_label(
             app=self.imviz.app,
             data_label="fits_wcs[DATA]",
             rotation_angle=5 * u.deg
         )
-        self.imviz.load_data(ndd, data_label=self.imviz.app._wcs_only_label)
-        assert self.imviz.app.data_collection[3].label == self.imviz.app._wcs_only_label
+        self.imviz.load_data(ndd, data_label='ndd')
+        assert self.imviz.app.data_collection[3].label == 'ndd'
 
         # Confirm that all data in collection are labeled.
         assert len(self.imviz.app.state.layer_icons) == 4  # 3 + 1
 
-        # Confirm the WCS-only layer is logged.
-        assert len(self.viewer.state.wcs_only_layers) == 1
+        # Confirm the new WCS-only layer is logged.
+        assert len(self.viewer.state.wcs_only_layers) == 2
 
         # Load a second WCS-only layer.
         ndd2 = wcs_utils._get_rotated_nddata_from_label(
@@ -144,12 +148,12 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
         assert len(self.imviz.app.data_collection) == 5  # 3 + 2
         assert len(self.imviz.app.state.layer_icons) == 5
 
-        # Confirm the WCS-only layer is logged.
-        assert len(self.viewer.state.wcs_only_layers) == 2
+        # Confirm the second WCS-only layer is logged
+        assert len(self.viewer.state.wcs_only_layers) == 3
 
         # First entry is image data and the default reference data.
         assert self.imviz.app.state.layer_icons["fits_wcs[DATA]"] == "a"
-        assert self.viewer.state.reference_data.label == "fits_wcs[DATA]"
+        assert self.viewer.state.reference_data.label == base_wcs_layer_label
 
         wcs_only_icon = "mdi-rotate-left"
 
@@ -168,8 +172,8 @@ class TestWCSOnly(BaseImviz_WCS_GWCS):
             assert self.imviz.app.state.layer_icons[data_label] == wcs_only_icon
 
         # Change reference back to normal data.
-        self.imviz.app._change_reference_data("fits_wcs[DATA]")
-        assert self.viewer.state.reference_data.label == "fits_wcs[DATA]"
+        self.imviz.app._change_reference_data(base_wcs_layer_label)
+        assert self.viewer.state.reference_data.label == base_wcs_layer_label
         for i in (3, 4):
             data_label = self.imviz.app.data_collection[i].label
             assert self.imviz.app.state.layer_icons[data_label] == wcs_only_icon

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -138,10 +138,8 @@ class BaseImviz_WCS_GWCS:
         # Load data into Imviz:
         # 1. Data with FITS WCS and unit.
         # 2. Data with GWCS (rotated w.r.t. FITS WCS) and no unit.
-        # 3. Data without WCS nor unit.
         imviz_helper.load_data(NDData(arr, wcs=w_fits, unit='electron/s'), data_label='fits_wcs')
         imviz_helper.load_data(NDData(arr, wcs=w_gwcs), data_label='gwcs')
-        imviz_helper.load_data(arr, data_label='no_wcs')
 
         self.wcs_1 = w_fits
         self.wcs_2 = w_gwcs

--- a/jdaviz/configs/imviz/tests/utils.py
+++ b/jdaviz/configs/imviz/tests/utils.py
@@ -236,7 +236,7 @@ def create_example_gwcs(shape):
     return gwcs_wcs.WCS(pipeline)
 
 
-def create_wfi_image_model(image_shape, **kwargs):
+def create_wfi_image_model(image_shape=(20, 10), **kwargs):
     """
     Create a dummy Roman WFI ImageModel instance with valid values
     for attributes required by the schema.

--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -563,7 +563,7 @@ def _get_latitude_axis_idx(wcs):
 
 
 def compute_scale(wcs, fiducial,
-                  disp_axis, pscale_ratio):
+                  disp_axis, pscale_ratio=1):
     """
     Compute scaling transform. This method comes from the `jwst` package:
         https://github.com/spacetelescope/jwst/blob/

--- a/jdaviz/container.vue
+++ b/jdaviz/container.vue
@@ -34,12 +34,12 @@
               :app_settings="app_settings"
               :layer_icons="layer_icons"
               :icons="icons"
+              :linked_by_wcs="viewer.linked_by_wcs"
               @data-item-visibility="$emit('data-item-visibility', $event)"
               @data-item-unload="$emit('data-item-unload', $event)"
               @data-item-remove="$emit('data-item-remove', $event)"
               @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select>
-
 
             <v-toolbar-items v-if="viewer.reference === 'table-viewer'">
               <j-tooltip tipid='table-prev'>
@@ -64,14 +64,14 @@
           <div v-if="app_settings.viewer_labels" class='viewer-label-container'>
             <div v-if="Object.keys(viewer_icons).length > 1" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <j-layer-viewer-icon span_style="float: right;" :icon="viewer_icons[viewer.id]"></j-layer-viewer-icon>
+                <j-layer-viewer-icon span_style="float: right;" :icon="viewer_icons[viewer.id]" :linked_by_wcs="viewer.linked_by_wcs"></j-layer-viewer-icon>
               </j-tooltip>
               <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">{{viewer.reference || viewer.id}}</span>
             </div>
 
             <div v-for="(layer_info, layer_name) in viewer.visible_layers" class="viewer-label invert-if-dark">
               <j-tooltip span_style="white-space: nowrap">
-                <j-layer-viewer-icon span_style="float: right;" :icon="layer_icons[layer_name]" :linewidth="layer_info.linewidth" :linestyle="'solid'" :color="layer_info.color"></j-layer-viewer-icon>
+                <j-layer-viewer-icon span_style="float: right;" :icon="layer_icons[layer_name]" :linewidth="layer_info.linewidth" :linestyle="'solid'" :color="layer_info.color" :linked_by_wcs="viewer.linked_by_wcs"></j-layer-viewer-icon>
               </j-tooltip>
               <span class="invert-if-dark" style="margin-left: 24px; margin-right: 32px; line-height: 24px">
                 <v-icon v-if="layer_info.prefix_icon" dense>

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -784,7 +784,9 @@ class LayerSelect(SelectPluginComponent):
     def __init__(self, plugin, items, selected, viewer,
                  multiselect=None,
                  default_text=None, manual_options=[],
-                 default_mode='first'):
+                 default_mode='first',
+                 include_wcs=False,
+                 only_wcs_layers=False):
         """
         Parameters
         ----------
@@ -805,6 +807,7 @@ class LayerSelect(SelectPluginComponent):
             ``default`` text is provided but not in ``manual_options`` it will still be included as
             the first item in the list.
         """
+
         super().__init__(plugin,
                          items=items,
                          selected=selected,
@@ -813,6 +816,9 @@ class LayerSelect(SelectPluginComponent):
                          default_text=default_text,
                          manual_options=manual_options,
                          default_mode=default_mode)
+
+        self.include_wcs = include_wcs
+        self.only_wcs_layers = only_wcs_layers
 
         self.hub.subscribe(self, AddDataMessage,
                            handler=lambda _: self._on_layers_changed())
@@ -865,12 +871,23 @@ class LayerSelect(SelectPluginComponent):
         viewers = [self._get_viewer(viewer) for viewer in viewer_names]
 
         manual_items = [{'label': label} for label in self.manual_options]
-        layers = [
-            layer for viewer in viewers
-            for layer in getattr(viewer, 'layers', [])
-            # don't include WCS-only layers:
-            if not layer.layer.meta.get('_WCS_ONLY', False)
-        ]
+
+        # use getattr so the super() call above doesn't try to access the attr before
+        # it is initialized:
+        if not getattr(self, 'only_wcs_layers', False):
+            layers = [
+                layer for viewer in viewers
+                for layer in getattr(viewer, 'layers', [])
+                # don't include WCS-only layers unless asked:
+                if not layer.layer.meta.get('_WCS_ONLY', False) or self.include_wcs
+            ]
+        else:
+            layers = [
+                layer for viewer in viewers
+                for layer in getattr(viewer, 'layers', [])
+                # only include WCS-only layers:
+                if layer.layer.meta.get('_WCS_ONLY', False)
+            ]
         # remove duplicates - NOTE: by doing this, any color-mismatch between layers with the
         # same name in different viewers will be randomly assigned within plot_options
         # based on which was found _first.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -879,8 +879,11 @@ class LayerSelect(SelectPluginComponent):
                 layer for viewer in viewers
                 for layer in getattr(viewer, 'layers', [])
                 # don't include WCS-only layers unless asked:
-                if not hasattr(layer.layer, 'meta') or
-                   (not layer.layer.meta.get('_WCS_ONLY', False) or self.include_wcs)
+                if (
+                    not hasattr(layer.layer, 'meta') or
+                    (not layer.layer.meta.get('_WCS_ONLY', False)
+                     or self.include_wcs)
+                )
             ]
         else:
             layers = [

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -865,7 +865,12 @@ class LayerSelect(SelectPluginComponent):
         viewers = [self._get_viewer(viewer) for viewer in viewer_names]
 
         manual_items = [{'label': label} for label in self.manual_options]
-        layers = [layer for viewer in viewers for layer in getattr(viewer, 'layers', [])]
+        layers = [
+            layer for viewer in viewers
+            for layer in getattr(viewer, 'layers', [])
+            # don't include WCS-only layers:
+            if not layer.layer.meta.get('_WCS_ONLY', False)
+        ]
         # remove duplicates - NOTE: by doing this, any color-mismatch between layers with the
         # same name in different viewers will be randomly assigned within plot_options
         # based on which was found _first.

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -879,14 +879,15 @@ class LayerSelect(SelectPluginComponent):
                 layer for viewer in viewers
                 for layer in getattr(viewer, 'layers', [])
                 # don't include WCS-only layers unless asked:
-                if not layer.layer.meta.get('_WCS_ONLY', False) or self.include_wcs
+                if not hasattr(layer.layer, 'meta') or
+                   (not layer.layer.meta.get('_WCS_ONLY', False) or self.include_wcs)
             ]
         else:
             layers = [
                 layer for viewer in viewers
                 for layer in getattr(viewer, 'layers', [])
                 # only include WCS-only layers:
-                if layer.layer.meta.get('_WCS_ONLY', False)
+                if not hasattr(layer.layer, 'meta') or layer.layer.meta.get('_WCS_ONLY', False)
             ]
         # remove duplicates - NOTE: by doing this, any color-mismatch between layers with the
         # same name in different viewers will be randomly assigned within plot_options

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.nddata import NDData
 from astropy.tests.helper import assert_quantity_allclose
 from glue.core import Data
 from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI, XRangeROI
@@ -466,7 +467,7 @@ def test_composite_region_with_consecutive_and_not_states(cubeviz_helper):
 
 
 def test_composite_region_with_imviz(imviz_helper, image_2d_wcs):
-    arr = np.ones((10, 10))
+    arr = NDData(np.ones((10, 10)), wcs=image_2d_wcs)
 
     data_label = 'image-data'
     viewer = imviz_helper.default_viewer

--- a/notebooks/concepts/imviz-wcs-rotation.ipynb
+++ b/notebooks/concepts/imviz-wcs-rotation.ipynb
@@ -112,9 +112,9 @@
    "id": "506f619b-f0a0-495c-8dd3-eec9a5d94896",
    "metadata": {},
    "source": [
-    "### Generate a set of WCS-only layers (with batch loading)\n",
+    "### Generate a set of WCS-only layers\n",
     "\n",
-    "Batch load a selection of WCS only layers:"
+    "Load the presets for WCS-only layers:"
    ]
   },
   {
@@ -128,26 +128,11 @@
    "source": [
     "lc = imviz.plugins['Links Control']\n",
     "\n",
-    "options = [\n",
-    "    dict(rotation_angle=\"0\", east_left=True),\n",
-    "    dict(rotation_angle=\"0\", east_left=False),\n",
-    "    dict(rotation_angle=\"40\", east_left=True),\n",
-    "    dict(rotation_angle=\"40\", east_left=False),\n",
-    "]\n",
+    "# make option for: North-up, East left\n",
+    "lc._obj.create_north_up_east_left()\n",
     "\n",
-    "with imviz.batch_load():\n",
-    "    # make option for: North-up, East left\n",
-    "    lc._obj.create_north_up_east_left()\n",
-    "\n",
-    "    # make option for: North-up, East right\n",
-    "    lc._obj.create_north_up_east_right()\n",
-    "\n",
-    "    for option in options:\n",
-    "        for attr in option:\n",
-    "            setattr(lc._obj, attr, option[attr])\n",
-    "        lc._obj.set_on_create = False\n",
-    "        lc._obj._update_layer_label_default()\n",
-    "        lc._obj.vue_create_new_orientation_from_data()\n",
+    "# make option for: North-up, East right\n",
+    "lc._obj.create_north_up_east_right()\n",
     "\n",
     "lc.open_in_tray()"
    ]

--- a/notebooks/concepts/imviz-wcs-rotation.ipynb
+++ b/notebooks/concepts/imviz-wcs-rotation.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ba79dc9f-5bbb-453e-be66-9d2e13253caa",
+   "metadata": {},
+   "source": [
+    "### Image rotation in Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f71fa4c3-1746-4bc2-9854-98eed319d155",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
+    "from astropy.utils.data import download_file\n",
+    "\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "from jdaviz import Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c63b7c3-cdf6-4c90-b978-1864fb4956f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cwd = './.'\n",
+    "\n",
+    "uris = [\n",
+    "    'mast:HST/product/j9dk11010_drz.fits',\n",
+    "    'mast:HST/product/j9dk11020_drz.fits',\n",
+    "    'mast:JWST/product/jw02731-o001_t017_nircam_clear-f200w_i2d.fits',\n",
+    "    'mast:jwst/product/jw02731-o001_t017_nircam_clear-f187n_i2d.fits'\n",
+    "]\n",
+    "\n",
+    "for uri in uris:\n",
+    "    path = cwd + uri.split('/')[-1]\n",
+    "    Observations.download_file(uri, local_path=path)\n",
+    "\n",
+    "tess_path = download_file(\n",
+    "    'https://mast.stsci.edu/api/v0.1/Download/file/' + \n",
+    "    '?uri=mast:TESS/product/tess2023107122157-s0064-3-2-0257-s_ffic.fits', \n",
+    "    cache=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "401af77b-907a-4dbc-bdb0-b60501f270e9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "\n",
+    "paths = [\n",
+    "    [cwd + 'jw02731-o001_t017_nircam_clear-f200w_i2d.fits', 'JWST/NIRCam F200W'],\n",
+    "    [cwd + 'jw02731-o001_t017_nircam_clear-f187n_i2d.fits', 'JWST/NIRCam F187W'],\n",
+    "    [cwd + 'j9dk11010_drz.fits', 'HST/ACS F658N (1)'],\n",
+    "    [cwd + 'j9dk11020_drz.fits', 'HST/ACS F658N (2)'],\n",
+    "    [tess_path, 'TESS FFI']\n",
+    "]\n",
+    "load_order = [0, 1, 2, 3, 4]\n",
+    "\n",
+    "with imviz.batch_load():\n",
+    "    for path, data_label in np.array(paths)[load_order]:\n",
+    "        imviz.load_data(path, data_label=data_label)\n",
+    "\n",
+    "po = imviz.plugins['Plot Options']\n",
+    "po.image_color_mode = 'Monochromatic'\n",
+    "\n",
+    "colors = np.array(['r', '#40eb34', '#03dbfc', '#03dbfc', 'y'])[load_order]\n",
+    "vmins = np.array([1.2, 5, 0, 0, 0])[load_order]\n",
+    "vmaxes = np.array([8, 150, 3, 3, 3e4])[load_order]\n",
+    "alphas = np.array([1, 1, 1, 1, 0.7])[load_order]\n",
+    "\n",
+    "zip_items = zip(\n",
+    "    imviz.app.data_collection, colors, alphas, vmins, vmaxes\n",
+    ")\n",
+    "\n",
+    "for i, (data, color, alpha, vmin, vmax) in enumerate(zip_items):\n",
+    "    if not data.label.startswith(\"CCW\"):\n",
+    "        po.layer = data.label\n",
+    "        po.stretch_function = 'arcsinh'\n",
+    "        po.image_opacity = alpha\n",
+    "        po.image_contrast = 1.15\n",
+    "        po.image_color = color\n",
+    "        po.stretch_vmin = vmin\n",
+    "        po.stretch_vmax = vmax\n",
+    "\n",
+    "imviz.link_data(link_type='wcs')\n",
+    "imviz.show('sidecar:split-right', height=1200)\n",
+    "\n",
+    "near_nebula = SkyCoord(159.22, -58.63, unit=u.deg)\n",
+    "imviz.default_viewer.center_on(near_nebula)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "506f619b-f0a0-495c-8dd3-eec9a5d94896",
+   "metadata": {},
+   "source": [
+    "### Generate a set of WCS-only layers (with batch loading)\n",
+    "\n",
+    "Batch load a selection of WCS only layers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f3a4f56-305e-4010-9f95-68b369737463",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lc = imviz.plugins['Links Control']\n",
+    "\n",
+    "options = [\n",
+    "    dict(rotation_angle=\"0\", east_left=True),\n",
+    "    dict(rotation_angle=\"0\", east_left=False),\n",
+    "    dict(rotation_angle=\"40\", east_left=True),\n",
+    "    dict(rotation_angle=\"40\", east_left=False),\n",
+    "]\n",
+    "\n",
+    "with imviz.batch_load():\n",
+    "    # make option for: North-up, East left\n",
+    "    lc._obj.create_north_up_east_left()\n",
+    "\n",
+    "    # make option for: North-up, East right\n",
+    "    lc._obj.create_north_up_east_right()\n",
+    "\n",
+    "    for option in options:\n",
+    "        for attr in option:\n",
+    "            setattr(lc._obj, attr, option[attr])\n",
+    "        lc._obj.set_on_create = False\n",
+    "        lc._obj._update_layer_label_default()\n",
+    "        lc._obj.vue_create_new_orientation_from_data()\n",
+    "\n",
+    "lc.open_in_tray()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc97a58-fadd-49d1-8829-da7478f1674e",
+   "metadata": {},
+   "source": [
+    "### Making WCS-only layers visible for debugging\n",
+    "\n",
+    "WCS-only reference data layers meant for linking/rotation will be invisible in the viewer, unless the user goes through the API to make them visible. Here's how you could do that, if you wanted to check where the rotated WCS lands in the FOV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20150693-a68f-42be-befa-ac5145e65876",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "make_wcs_only_layers_visible = False\n",
+    "\n",
+    "for i, layer in enumerate(imviz.default_viewer.layers):\n",
+    "    if hasattr(layer.layer, 'meta') and layer.layer.meta.get('_WCS_ONLY', False):\n",
+    "        layer.visible = make_wcs_only_layers_visible\n",
+    "        layer.update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4129ca07-370b-4ea9-a21d-b20802560ee6",
+   "metadata": {},
+   "source": [
+    "### Multiple viewers with their own orientations\n",
+    "\n",
+    "New viewers can be added and given separate rotation settings: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a56fc3e-e810-465b-b4c2-73c3c24c3e19",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# create new viewer:\n",
+    "imviz.create_image_viewer('imviz-1')\n",
+    "\n",
+    "# add a data entry into the new viewer:\n",
+    "imviz.app.add_data_to_viewer('imviz-1', imviz.app.data_collection[1].label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c926c5ff-b9fc-4fc6-8cf8-95fe631b86af",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description

Implements the Links Control plugin updates for #2179. [🐱](https://jira.stsci.edu/browse/JDAT-3335)

### Features implemented
* Data dropdown menu now has an "orientation options" expandable section when linked by WCS in Imviz, which contains the WCS-only layers. Clicking on an orientation option will set it as reference data, causing the viewer orientation to rotate
* Support for switching between pixel/WCS linking and back again. WCS-only layers are not visible in the data menu dropdown when pixel linked.
* better support for FITS WCS and gwcs
* plugin layer selector ignores WCS-only layers for plugins that need you to choose a data entry (unless that's specifically what you want, in which case, it can give you only the WCS only layers)
* Links Control plugin now has a "Select orientation" section which allows you to select one orientation option per viewer
* Links Control plugin now has a "Add orientation option" section which allows you to specify a rotation angle relative to the default orientation, with east left or right, and optionally select it as reference data (thus rotating the viewer)
* there's partial support for batch loading WCS-only layers. It works _sometimes_, but I haven't tracked down yet why it doesn't work 100% of the time.
* tests throughout jdaviz have been updated where the answers change due to the reference data changing.

### Demo videos

There's a lot to demo, so the videos are too large to upload to GitHub. I've put them on Box, and they should be available to reviewers, and viewable in the browser. Unlike many of our demo videos, these have audio, so turn up the sound to hear me ramble: https://stsci.box.com/s/o6tbem7qiq2ybdhxhgd86ql484i0tdjt

The demo videos are based on the notebook that's included in this PR at: `notebooks/concepts/imviz-wcs-rotation.ipynb`.

When you review these videos, you may wonder: how do I know that the N-up/E-left setting is the correct orientation? Here's a link to an Aladin Lite preview of this nebula, allowing you to see North-up East-left by default: https://aladin.cds.unistra.fr/AladinLite/?target=10%2036%2053.710-58%2039%2034.45&fov=0.17&survey=CDS%2FP%2FDECaPS%2FDR2%2Fcolor

devdeps tests are expected to fail due to: https://github.com/glue-viz/glue-jupyter/pull/363#pullrequestreview-1528650930