### PR TITLE
deprecate canvas rotation

### DIFF
--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -352,6 +352,11 @@ To import a regions file or object from the API:
 Canvas Rotation
 ===============
 
+.. note::
+
+    This plugin is deprecated in favor of rotation via :ref:`imviz-link-control` and will be removed
+    in a future release.
+
 The canvas rotation plugin allows rotating and horizontally flipping the image to any arbitrary 
 value by rotating the canvas axes themselves.  Note that this does not affect the underlying data, and
 exporting data to the notebook via the API will therefore not exhibit the same rotation.

--- a/docs/imviz/plugins.rst
+++ b/docs/imviz/plugins.rst
@@ -354,7 +354,7 @@ Canvas Rotation
 
 .. note::
 
-    This plugin is deprecated in favor of rotation via :ref:`imviz-link-control` and will be removed
+    This plugin is deprecated in favor of rotation via :ref:`imviz-orientation` and will be removed
     in a future release.
 
 The canvas rotation plugin allows rotating and horizontally flipping the image to any arbitrary 

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.py
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.py
@@ -1,5 +1,4 @@
 import os
-from astropy.utils.decorators import deprecated
 from traitlets import Bool, Unicode, observe
 
 from glue_jupyter.common.toolbar_vuetify import read_icon
@@ -51,7 +50,6 @@ class RotateCanvas(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
     @property
-    @deprecated(since="3.9", alternative="Links Control plugin")
     def user_api(self):
         return PluginUserApi(self, expose=('viewer', 'angle', 'flip_horizontal', 'reset',
                                            'set_north_up_east_right', 'set_north_up_east_left'))

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.py
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.py
@@ -1,4 +1,5 @@
 import os
+from astropy.utils.decorators import deprecated
 from traitlets import Bool, Unicode, observe
 
 from glue_jupyter.common.toolbar_vuetify import read_icon
@@ -50,6 +51,7 @@ class RotateCanvas(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, RemoveDataMessage, handler=self._on_viewer_data_changed)
 
     @property
+    @deprecated(since="3.9", alternative="Links Control plugin")
     def user_api(self):
         return PluginUserApi(self, expose=('viewer', 'angle', 'flip_horizontal', 'reset',
                                            'set_north_up_east_right', 'set_north_up_east_left'))

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
@@ -4,6 +4,12 @@
     :link="docs_link || 'https://jdaviz.readthedocs.io/en/'+vdocs+'/'+config+'/plugins.html#canvas-rotation'"
     :disabled_msg="isChromium() ? '' : 'Image rotation is not supported by your browser. Please see our docs for more information.'"
     :popout_button="popout_button">
+
+    <v-alert type='warning'>
+      This plugin is deprecated in favor of rotation via Links Control and will be removed
+      in a future release.
+    </v-alert>
+
     <plugin-viewer-select
       :items="viewer_items"
       :selected.sync="viewer_selected"

--- a/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
+++ b/jdaviz/configs/imviz/plugins/rotate_canvas/rotate_canvas.vue
@@ -6,7 +6,7 @@
     :popout_button="popout_button">
 
     <v-alert type='warning'>
-      This plugin is deprecated in favor of rotation via Links Control and will be removed
+      This plugin is deprecated in favor of rotation via the Orientation plugin and will be removed
       in a future release.
     </v-alert>
 

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -125,7 +125,9 @@ class ConfigHelper(HubListener):
         # handle renamed plugins during deprecation
         if 'Orientation' in plugins.keys():
             plugins['Links Control'] = plugins['Orientation']._obj.user_api
-            plugins['Links Control']._deprecated_renamed_as = 'Orientation'
+            plugins['Links Control']._deprecation_msg = 'in the future, the formerly named \"Links Control\" plugin will only be available by its new name: \"Orientation\".'  # noqa
+        if 'Canvas Rotation' in plugins.keys():
+            plugins['Canvas Rotation']._deprecation_msg = 'this functionality will be removed in favor of the implementation for rotation in the \"Orientation\" plugin.'  # noqa
 
         return plugins
 

--- a/jdaviz/core/user_api.py
+++ b/jdaviz/core/user_api.py
@@ -3,7 +3,7 @@ import astropy.units as u
 
 __all__ = ['UserApiWrapper', 'PluginUserApi']
 
-_internal_attrs = ('_obj', '_expose', '_readonly', '__doc__', '_deprecated_renamed_as')
+_internal_attrs = ('_obj', '_expose', '_readonly', '__doc__', '_deprecation_msg')
 
 
 class UserApiWrapper:
@@ -93,23 +93,23 @@ class PluginUserApi(UserApiWrapper):
         expose = list(set(list(expose) + ['open_in_tray', 'show']))
         if plugin.uses_active_status:
             expose += ['keep_active', 'as_active']
-        self._deprecated_renamed_as = None
+        self._deprecation_msg = None
         super().__init__(plugin, expose, readonly)
 
     def __repr__(self):
-        if self._deprecated_renamed_as:
-            logging.warning(f"DeprecationWarning: in the future, this plugin API will only be available by its new name '{self._deprecated_renamed_as}'")  # noqa
-            super().__setattr__('_deprecated_renamed_as', None)
+        if self._deprecation_msg:
+            logging.warning(f"DeprecationWarning: {self._deprecation_msg}")
+            super().__setattr__('_deprecation_msg', None)
         return f'<{self._obj._registry_label} API>'
 
     def __getattr__(self, *args, **kwargs):
-        if super().__getattr__('_deprecated_renamed_as'):
-            logging.warning(f"DeprecationWarning: in the future, this plugin API will only be available by its new name '{self._deprecated_renamed_as}'")  # noqa
-            super().__setattr__('_deprecated_renamed_as', None)
+        if super().__getattr__('_deprecation_msg'):
+            logging.warning(f"DeprecationWarning: {self._deprecation_msg}")
+            super().__setattr__('_deprecation_msg', None)
         return super().__getattr__(*args, **kwargs)
 
     def __setattr__(self, *args, **kwargs):
-        if hasattr(self, '_deprecated_renamed_as') and self._deprecated_renamed_as:
-            logging.warning(f"DeprecationWarning: in the future, this plugin API will only be available by its new name '{self._deprecated_renamed_as}'")  # noqa
-            super().__setattr__('_deprecated_renamed_as', None)
+        if hasattr(self, '_deprecation_msg') and self._deprecation_msg:
+            logging.warning(f"DeprecationWarning: {self._deprecation_msg}")
+            super().__setattr__('_deprecation_msg', None)
         return super().__setattr__(*args, **kwargs)


### PR DESCRIPTION
This PR adds deprecation warnings for "Canvas Rotation" into the docs, plugin UI, and plugin user API.  Note that we will need to update the version in the deprecation decorator (since this deprecation definitely won't be released in 3.6) as well as update any references to "Links Control" if we decide to rename that as part of this larger effort.

Alternatively we could get this in to main and released in 3.6, but we have nothing to point to as an alternate option yet.