### PR TITLE
Delete/warn/raise error when subsets exist during rotation

### DIFF
--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -129,7 +129,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
             self,
             expose=(
                 'link_type', 'wcs_use_affine', 'viewer',
-                'layer', 'rotation_angle', 'east_left'
+                'layer', 'rotation_angle', 'east_left', 'delete_subsets'
             )
         )
 
@@ -185,7 +185,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
             raise ValueError("Link type can only be changed after existing subsets "
                              f"are deleted, but {len(self.app.data_collection.subset_groups)} "
                              f"subset(s) still exist. To delete them, you can use "
-                             f"`imviz.plugins['Links Control'].delete_subsets()`.")
+                             f"`delete_subsets()` from the plugin API.")
 
         self.linking_in_progress = True
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -1,7 +1,9 @@
 import os
 from traitlets import List, Unicode, Bool, observe
 
-from glue.core.message import DataCollectionAddMessage
+from glue.core.message import (
+    DataCollectionAddMessage, SubsetCreateMessage, SubsetDeleteMessage
+)
 from glue.core.subset import Subset
 from glue.core.subset_group import GroupedSubset
 from glue_jupyter.common.toolbar_vuetify import read_icon
@@ -58,6 +60,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
 
     need_clear_markers = Bool(False).tag(sync=True)
     linking_in_progress = Bool(False).tag(sync=True)
+    need_clear_subsets = Bool(False).tag(sync=True)
 
     # rotation angle, counterclockwise [degrees]
     rotation_angle = FloatHandleEmpty(0).tag(sync=True)
@@ -113,6 +116,12 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
 
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_refdata_change)
+
+        self.hub.subscribe(self, SubsetCreateMessage,
+                           handler=self._on_subset_change)
+
+        self.hub.subscribe(self, SubsetDeleteMessage,
+                           handler=self._on_subset_change)
 
     @property
     def user_api(self):
@@ -172,6 +181,12 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
         if self.linking_in_progress:
             return
 
+        if self.need_clear_subsets:
+            raise ValueError("Link type can only be changed after existing subsets "
+                             f"are deleted, but {len(self.app.data_collection.subset_groups)} "
+                             f"subset(s) still exist. To delete them, you can use "
+                             f"`imviz.plugins['Links Control'].delete_subsets()`.")
+
         self.linking_in_progress = True
 
         if self.need_clear_markers:
@@ -186,6 +201,17 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
 
         self._link_image_data()
         self.linking_in_progress = False
+
+    def _on_subset_change(self, msg):
+        self.need_clear_subsets = len(self.app.data_collection.subset_groups) > 0
+
+    def delete_subsets(self):
+        # subsets will be deleted on changing link type:
+        for subset_group in self.app.data_collection.subset_groups:
+            self.app.data_collection.remove_subset_group(subset_group)
+
+    def vue_delete_subsets(self, *args):
+        self.delete_subsets()
 
     def vue_reset_markers(self, *args):
         for viewer in self.app._viewer_store.values():

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -12,6 +12,7 @@
           label="Link type"
           hint="Type of linking to be done."
           v-model="link_type_selected"
+          @change="delete_subsets($event)"
           persistent-hint
           row>
           <v-radio
@@ -21,6 +22,11 @@
             :value="item.label"
           ></v-radio>
         </v-radio-group>
+        <div v-if="need_clear_subsets">
+          <v-alert type='warning' style="margin-left: -12px; margin-right: -12px">
+              Existing subsets will be deleted on changing link type.
+          </v-alert>
+        </div>
         </v-row>
 
         <v-row>
@@ -172,5 +178,4 @@
 div[role=radiogroup] > legend {
   width: 100%;
 }
-
 </style>

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -6,12 +6,12 @@ from jdaviz.configs.imviz.tests.test_linking import _transform_refdata_pixel_coo
 
 class TestImvizSpatialSubsetCentroid(BaseImviz_WCS_GWCS):
     def test_centroiding(self):
+        # FITS WCS and GWCS are rotated from each other.
+        self.imviz.link_data(link_type='wcs')
+
         reg = CirclePixelRegion(PixCoord(2, 2), 3)
 
         self.imviz.load_regions(reg)
-
-        # FITS WCS and GWCS are rotated from each other.
-        self.imviz.link_data(link_type='wcs')
 
         plg = self.imviz.plugins['Subset Tools']
         plg._obj.subset_selected = 'Subset 1'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

The image rotation implementation in https://github.com/spacetelescope/jdaviz/pull/2179 changes the reference data. Subsets defined with one reference data are not updated/redefined when the reference data change (yet), so they become meaningless after a reference data change. Our plan for now is to delete all subsets when the user changes link type in Imviz in https://github.com/spacetelescope/jdaviz/pull/2179, since that operation changes the reference data. 

The plugin will show a warning in the Links Control plugin when there are subsets to indicate that they will be deleted if you change link type. If the user changes the link type from the plugin UI, the existing subsets will be deleted. Users who try to change the link type from the API with `imviz.plugins['Links Control'].link_type = ...` will raise a `ValueError` if subsets exist, demanding that they be deleted before the operation can be done.

[🐱](https://jira.stsci.edu/browse/JDAT-3642)
