### PR TITLE
Better Imviz handling w/o WCS when WCS-linked

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -190,20 +190,36 @@ class Imviz(ImageConfigHelper):
         # above instead of having to refind it
         applied_labels = []
         applied_visible = []
-        applied_is_wcs = []
+        layer_is_wcs_only = []
+        layer_has_wcs = []
         for data in self.app.data_collection:
             label = data.label
             if label not in prev_data_labels:
                 applied_labels.append(label)
                 applied_visible.append(True)
-                applied_is_wcs.append(data.meta.get(self.app._wcs_only_label, False))
+                layer_is_wcs_only.append(data.meta.get(self.app._wcs_only_label, False))
+                layer_has_wcs.append(hasattr(data.coords, 'pixel_to_world'))
 
         if show_in_viewer is True:
             show_in_viewer = f"{self.app.config}-0"
 
+        if show_in_viewer:
+            linked_by_wcs = self.app._link_type == 'wcs'
+            if linked_by_wcs:
+                for applied_label, visible, is_wcs_only, has_wcs in zip(
+                        applied_labels, applied_visible, layer_is_wcs_only, layer_has_wcs
+                ):
+                    if not is_wcs_only and linked_by_wcs and not has_wcs:
+                        self.app.hub.broadcast(SnackbarMessage(
+                            f"'{applied_label}' will be added to the data collection but not "
+                            f"the viewer '{show_in_viewer}', since data are linked by WCS, but "
+                            f"'{applied_label}' has no WCS.",
+                            color="warning", timeout=8000, sender=self)
+                        )
+
         if self._in_batch_load and show_in_viewer:
-            for applied_label, layer_is_wcs in zip(applied_labels, applied_is_wcs):
-                if not layer_is_wcs:
+            for applied_label, is_wcs_only in zip(applied_labels, layer_is_wcs_only):
+                if not is_wcs_only:
                     self._delayed_show_in_viewer_labels[applied_label] = show_in_viewer
 
         elif do_link:
@@ -215,8 +231,11 @@ class Imviz(ImageConfigHelper):
             # NOTE: this will not add entries that were skipped with do_link=False
             # but the batch_load context manager will handle that logic
             if show_in_viewer:
-                for applied_label, visible in zip(applied_labels, applied_visible):
-                    self.app.add_data_to_viewer(show_in_viewer, applied_label, visible=visible)
+                for applied_label, visible, has_wcs in zip(
+                        applied_labels, applied_visible, layer_has_wcs
+                ):
+                    if (has_wcs and linked_by_wcs) or not linked_by_wcs:
+                        self.app.add_data_to_viewer(show_in_viewer, applied_label, visible=visible)
         else:
             warnings.warn(AstropyDeprecationWarning("do_link=False is deprecated in v3.1 and will "
                                                     "be removed in a future release.  Use with "
@@ -495,11 +514,11 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         raise ValueError("wcs_fallback_scheme must be None or 'pixels', "
                          f"got {wcs_fallback_scheme}")
     if link_type == 'wcs':
-        all_data_have_wcs = all([
+        at_least_one_data_have_wcs = len([
             hasattr(d, 'coords') and isinstance(d.coords, (BaseHighLevelWCS, GWCS))
             for d in app.data_collection
-        ])
-        if not all_data_have_wcs:
+        ]) > 1
+        if not at_least_one_data_have_wcs:
             if wcs_fallback_scheme is None:
                 if error_on_fail:
                     raise ValueError("link_type can only be 'wcs' when wcs_fallback_scheme "
@@ -590,7 +609,8 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         try:
             if link_type == 'pixels':
                 new_links = [LinkSame(ids0[i], ids1[i]) for i in ndim_range]
-            else:  # 'wcs'
+            # otherwise if linking by WCS *and* this data entry has WCS:
+            elif hasattr(data.coords, 'pixel_to_world'):
                 wcslink = WCSLink(data1=refdata, data2=data, cids1=ids0, cids2=ids1)
                 if wcs_use_affine:
                     try:

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -201,6 +201,30 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
             self.wcs_use_affine = True
 
         self._link_image_data()
+
+        # load data into the viewer that are now compatible with the
+        # new link type, remove data from the viewer that are now
+        # incompatible:
+        wcs_linked = self.link_type.selected.lower() == 'wcs'
+        viewer_selected = self.app.get_viewer(self.viewer.selected)
+
+        data_in_viewer = self.app.get_viewer(viewer_selected.reference).data()
+
+        for data in self.app.data_collection:
+            is_wcs_only = data.meta.get(self.app._wcs_only_label, False)
+            has_wcs = hasattr(data.coords, 'pixel_to_world')
+            if not is_wcs_only:
+                if data not in data_in_viewer:
+                    # add data from viewer:
+                    if wcs_linked and has_wcs:
+                        self.app.add_data_to_viewer(viewer_selected.reference, data.label)
+                    elif not wcs_linked:
+                        self.app.add_data_to_viewer(viewer_selected.reference, data.label)
+
+                elif wcs_linked and not has_wcs:
+                    # data is in viewer but must be removed:
+                    self.app.remove_data_from_viewer(viewer_selected.reference, data.label)
+
         self.linking_in_progress = False
         self._update_layer_label_default()
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

In the image rotation PR https://github.com/spacetelescope/jdaviz/pull/2179, if the user loaded data without WCS into Imviz while WCS-linked, the new data entry would be added to the data collection but not added to the viewer. No visible warning was raised to indicate that the data could not be added to the viewer, which could be confusing if the user did not realize their data had no WCS, or that they were WCS-linked on load.

This PR adds a snackbar warning if data without WCS are loaded into a viewer that is WCS-linked. It also loops through the data collection when `link_type` is changed to add or remove data from the viewer, to add data back to the viewer if they'll be compatible with the new `link_type`.

I tested this using the following example: 
```python
import os
import numpy as np
from astroquery.mast import Observations
from jdaviz import Imviz

cwd = '../example_files/'

os.makedirs(cwd, exist_ok=True)

uris = [
    'mast:HST/product/j9dk11010_drz.fits',
    'mast:HST/product/j9dk11020_drz.fits',
]

for uri in uris:
    path = cwd + uri.split('/')[-1]
    if not os.path.exists(path):
        Observations.download_file(uri, local_path=path)

imviz = Imviz()

paths = [
    [cwd + 'j9dk11010_drz.fits', 'HST/ACS F658N (1)'],
    [cwd + 'j9dk11020_drz.fits', 'HST/ACS F658N (2)'],
]

# load data with WCS:
with imviz.batch_load():
    for path, data_label in paths:
        imviz.load_data(path, data_label=data_label)

# link by WCS

imviz.link_data(link_type='wcs')

imviz.show()


# load data without WCS:
imviz.load_data(np.random.normal(scale=10, size=(4000, 4000)))
```

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

 [🐱](https://jira.stsci.edu/browse/JDAT-3640)