### PR TITLE
Better viewer zoom/center sync with different refdata

### DIFF
--- a/jdaviz/configs/imviz/plugins/tools.py
+++ b/jdaviz/configs/imviz/plugins/tools.py
@@ -20,24 +20,7 @@ class _ImvizMatchedZoomMixin(_MatchedZoomMixin):
 
     def _is_matched_viewer(self, viewer):
         # only match zooms in viewers that share reference data
-        return (
-            isinstance(viewer, BqplotImageView) and
-            viewer.state.reference_data == self.viewer.state.reference_data
-        )
-
-    def _post_activate(self):
-        # NOTE: For Imviz only.
-        # Set the reference data in other viewers to be the same as the current viewer.
-        # If adding the data to the viewer, make sure it is not actually shown since the
-        # user didn't request it.
-        for viewer in self._iter_matched_viewers(include_self=False):
-            if self.viewer.state.reference_data not in viewer.state.layers_data:
-                viewer.add_data(self.viewer.state.reference_data)
-                for layer in viewer.state.layers:
-                    if layer.layer is self.viewer.state.reference_data:
-                        layer.visible = False
-                        break
-            viewer.state.reference_data = self.viewer.state.reference_data
+        return isinstance(viewer, BqplotImageView)
 
 
 @viewer_tool

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -211,10 +211,12 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         they are linked by WCS.
         """
         if self.state.reference_data.meta.get('_WCS_ONLY', False):
-            # Convert X,Y from reference data to the one we are actually seeing.
-            x = image.coords.world_to_pixel(self.state.reference_data.coords.pixel_to_world(
+            corner_world_coords = self.state.reference_data.coords.pixel_to_world(
                 (self.state.x_min, self.state.x_min, self.state.x_max, self.state.x_max),
-                (self.state.y_min, self.state.y_max, self.state.y_max, self.state.y_min)))
+                (self.state.y_min, self.state.y_max, self.state.y_max, self.state.y_min)
+            )
+            # Convert X,Y from reference data to the one we are actually seeing.
+            x = image.coords.world_to_pixel(corner_world_coords)
             zoom_limits = np.array(list(zip(x[0], x[1])))
         else:
             zoom_limits = np.array(((self.state.x_min, self.state.y_min),


### PR DESCRIPTION
At time of writing, https://github.com/spacetelescope/jdaviz/pull/2179 un-syncs the pan and zoom between viewers in Imviz when different reference data are selected in each viewer, and re-syncs them when the reference data are made to match.

This PR syncs the sky centroids of the FOV in each viewer, and approximately syncs the zoom level. I say the zoom sync is "approximate" because we can't uniformly assign one set of `{x/y}_{min/max}` for all viewers when any are allowed to have different reference data (/rotation). Instead, I compute the average width of each side of the active viewer in world coordinates, and set the zoom level in the other viewers to match the active viewer's width. 

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)? [🐱](https://jira.stsci.edu/browse/JDAT-3643)
