### PR TITLE
Support image rotation in markers plugin

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -290,7 +290,7 @@ class Application(VuetifyTemplate, HubListener):
 
         # Imviz linking
         self._wcs_only_label = "_WCS_ONLY"
-        self._link_type = None
+        self._link_type = 'pixels'
         if self.config == "imviz":
             self._wcs_use_affine = None
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -121,8 +121,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             viewer_mark.x, viewer_mark.y = [], []
             return
 
-        orig_world_x = self.table._qtable['world'][:, 0][in_viewer]
-        orig_world_y = self.table._qtable['world'][:, 1][in_viewer]
+        orig_world_x = np.asarray(self.table._qtable['world'][:, 0][in_viewer])
+        orig_world_y = np.asarray(self.table._qtable['world'][:, 1][in_viewer])
 
         if self.app._link_type == 'wcs':
             if new_wcs is None:
@@ -133,9 +133,9 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             except Exception:
                 # fail gracefully
                 new_x, new_y = [], []
-        else:
-            # then pixel linked, so we need to convert based on the WCS of the individual data
-            # layers on which each mark was first created
+        elif self.app._link_type == 'pixels':
+            # we need to convert based on the WCS of the individual data layers on which each mark
+            # was first created
             new_x, new_y = np.zeros_like(orig_world_x), np.zeros_like(orig_world_y)
             for data_label in np.unique(data_labels[in_viewer]):
                 these = data_labels[in_viewer] == data_label
@@ -149,6 +149,19 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                     # fail gracefully
                     new_x, new_y = [], []
                     break
+        else:
+            raise NotImplementedError(f"link_type {self.app._link_type} not implemented")
+
+        # check for entries that do not correspond to a layer or only have pixel coordinates
+        pixel_only_inds = data_labels == ''
+        if np.any(pixel_only_inds):
+            # TODO: should we rescale these since pixel coordinates when linked by WCS are always
+            # on the range 0-1 because of the orientation layer?  Or hide the pixel option in the
+            # cycler when WCS-linked?
+            pixel_x = np.asarray(self.table._qtable['pixel'][:, 0])
+            pixel_y = np.asarray(self.table._qtable['pixel'][:, 1])
+            new_x = np.append(new_x, pixel_x[pixel_only_inds])
+            new_y = np.append(new_y, pixel_y[pixel_only_inds])
 
         viewer_mark.x, viewer_mark.y = new_x, new_y
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -128,12 +128,10 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             if new_wcs is None:
                 new_wcs = viewer.state.reference_data.coords
             try:
-                new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg,
-                                                      orig_world_y*u.deg)
-            except ValueError:
-                # can temporarily fail with "ValueError: Number of world inputs (2) does not match
-                # expected (1)", in which case we'll temporarily clear markers and should resolve
-                # itself on the next message
+                new_x, new_y = new_wcs.world_to_pixel_values(orig_world_x*u.deg,
+                                                             orig_world_y*u.deg)
+            except Exception:
+                # fail gracefully
                 new_x, new_y = [], []
         else:
             # then pixel linked, so we need to convert based on the WCS of the individual data
@@ -145,9 +143,10 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                     continue
                 wcs = self.app.data_collection[data_label].coords
                 try:
-                    new_x[these], new_y[these] = wcs.world_to_pixel(orig_world_x[these]*u.deg,
-                                                                    orig_world_y[these]*u.deg)
-                except ValueError:
+                    new_x[these], new_y[these] = wcs.world_to_pixel_values(orig_world_x[these]*u.deg,  # noqa
+                                                                           orig_world_y[these]*u.deg)  # noqa
+                except Exception:
+                    # fail gracefully
                     new_x, new_y = [], []
                     break
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -106,6 +106,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def _recompute_mark_positions(self, viewer, new_wcs=None):
         if self.table is None or self.table._qtable is None:
             return
+        if 'world' not in self.table.headers_avail:
+            return
 
         viewer_id = viewer.reference if viewer.reference is not None else viewer.reference_id
         viewer_loaded_data = [lyr.layer.label for lyr in viewer.layers]

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -107,9 +107,14 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         if self.table is None or self.table._qtable is None:
             return
 
-        viewer_labels = [lyr.layer.label for lyr in viewer.layers]
+        viewer_id = viewer.reference if viewer.reference is not None else viewer.reference_id
+        viewer_loaded_data = [lyr.layer.label for lyr in viewer.layers]
         data_labels = self.table._qtable['data_label']
-        in_viewer = [data_label in viewer_labels for data_label in data_labels]
+        viewer_labels = self.table._qtable['viewer']
+        # note: could eventually have a user-provided switch to show markers in other viewers
+        # by just skipping this first viewer_label == viewer_id check
+        in_viewer = [viewer_label == viewer_id and data_label in viewer_loaded_data
+                     for viewer_label, data_label in zip(viewer_labels, data_labels)]
 
         viewer_mark = self._get_mark(viewer)
         if not np.any(in_viewer):

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -84,8 +84,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
         # account for image rotation due to a change in reference data
         self.hub.subscribe(self, ChangeRefDataMessage,
-                           handler=lambda msg: self._recompute_mark_positions(msg.viewer,
-                                                                              new_wcs=msg.data.coords))  # noqa
+                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
 
         # enable/disable mark based on whether parent data entry is in viewer
         self.hub.subscribe(self, AddDataMessage,
@@ -104,7 +103,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def _on_viewer_added(self, msg):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
-    def _recompute_mark_positions(self, viewer, new_wcs=None):
+    def _recompute_mark_positions(self, viewer):
         if self.table is None or self.table._qtable is None:
             return
         if 'world' not in self.table.headers_avail:
@@ -128,8 +127,9 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         orig_world_y = np.asarray(self.table._qtable['world'][:, 1][in_viewer])
 
         if self.app._link_type == 'wcs':
-            if new_wcs is None:
-                new_wcs = viewer.state.reference_data.coords
+            # convert from the sky coordinates in the table to pixels via the WCS of the current
+            # reference data
+            new_wcs = viewer.state.reference_data.coords
             try:
                 new_x, new_y = new_wcs.world_to_pixel_values(orig_world_x*u.deg,
                                                              orig_world_y*u.deg)

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -1,7 +1,8 @@
 import numpy as np
+from astropy import units as u
 from traitlets import Bool, observe
 
-from jdaviz.core.events import ViewerAddedMessage
+from jdaviz.core.events import ViewerAddedMessage, ChangeRefDataMessage
 from jdaviz.core.marks import MarkersMark
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin, TableMixin
@@ -53,7 +54,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             headers = ['pixel', 'pixel:unreliable',
                        'world', 'world:unreliable',
                        'value', 'value:unit', 'value:unreliable',
-                       'viewer']
+                       'viewer', 'link_type', 'reference_data']
 
         elif self.config == 'specviz':
             headers = ['spectral_axis', 'spectral_axis:unit',
@@ -79,6 +80,9 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         # subscribe to mouse events on any new viewers
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
+        # account for image rotation due to a change in reference data
+        self.hub.subscribe(self, ChangeRefDataMessage, handler=self._on_refdata_change)
+
     def _create_viewer_callbacks(self, viewer):
         if not self.is_active:
             return
@@ -88,6 +92,17 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
     def _on_viewer_added(self, msg):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
+
+    def _on_refdata_change(self, msg):
+        viewer_mark = self._get_mark(msg.viewer)
+        # we act from the previous state instead of the original since the original WCS may have
+        # been deleted.  If this causes a buildup in errors, we could first try to access the
+        # original or cache its WCS in the table so we always have access.
+        prev_x, prev_y = viewer_mark.x, viewer_mark.y
+        prev_wcs = msg.old.coords
+        new_wcs = msg.data.coords
+        new_x, new_y = new_wcs.world_to_pixel(prev_wcs.pixel_to_world(prev_x*u.pix, prev_y*u.pix))
+        viewer_mark.x, viewer_mark.y = new_x, new_y
 
     def _get_mark(self, viewer):
         matches = [mark for mark in viewer.figure.marks if isinstance(mark, MarkersMark)]

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -2,7 +2,8 @@ import numpy as np
 from astropy import units as u
 from traitlets import Bool, observe
 
-from jdaviz.core.events import ViewerAddedMessage, ChangeRefDataMessage
+from jdaviz.core.events import (ViewerAddedMessage, ChangeRefDataMessage,
+                                AddDataMessage, RemoveDataMessage)
 from jdaviz.core.marks import MarkersMark
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin, TableMixin
@@ -81,7 +82,15 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_viewer_added)
 
         # account for image rotation due to a change in reference data
-        self.hub.subscribe(self, ChangeRefDataMessage, handler=self._on_refdata_change)
+        self.hub.subscribe(self, ChangeRefDataMessage,
+                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
+
+        # enable/disable mark based on whether parent data entry is in viewer
+        self.hub.subscribe(self, AddDataMessage,
+                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
+
+        self.hub.subscribe(self, RemoveDataMessage,
+                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
 
     def _create_viewer_callbacks(self, viewer):
         if not self.is_active:
@@ -93,26 +102,34 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def _on_viewer_added(self, msg):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
-    def _on_refdata_change(self, msg):
-        viewer_mark = self._get_mark(msg.viewer)
+    def _recompute_mark_positions(self, viewer):
+        if self.table is None or self.table._qtable is None:
+            return
 
-        # TODO: when a data layer is unloaded from the viewer, the marks need to be hidden
-        # and re-shown when added back to the viewer.  When deleted from the app, should the
-        # rows in the table be cleared?  This will then account for the case where a
-        # mark is added to data without WCS that is dropped when changing from pixel->WCS linking
-        orig_world_x = self.table._qtable['world'][:, 0]
-        orig_world_y = self.table._qtable['world'][:, 1]
+        viewer_labels = [lyr.layer.label for lyr in viewer.layers]
+        data_labels = self.table._qtable['data_label']
+        in_viewer = [data_label in viewer_labels for data_label in data_labels]
+
+        viewer_mark = self._get_mark(viewer)
+        if not np.any(in_viewer):
+            viewer_mark.x, viewer_mark.y = [], []
+            return
+
+        orig_world_x = self.table._qtable['world'][:, 0][in_viewer]
+        orig_world_y = self.table._qtable['world'][:, 1][in_viewer]
 
         if self.app._link_type == 'wcs':
-            new_wcs = msg.data.coords
-            new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg, orig_world_y*u.deg)
+            new_wcs = viewer.state.reference_data.coords
+            new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg,
+                                                  orig_world_y*u.deg)
         else:
-            # need to convert based on the WCS of the individual data layers on which the mark
-            # was created
-            data_labels = self.table._qtable['data_label']
+            # then pixel linked, so we need to convert based on the WCS of the individual data
+            # layers on which each mark was first created
             new_x, new_y = np.zeros_like(orig_world_x), np.zeros_like(orig_world_y)
-            for data_label in np.unique(data_labels):
-                these = data_labels == data_label
+            for data_label in np.unique(data_labels[in_viewer]):
+                these = data_labels[in_viewer] == data_label
+                if not np.any(these):
+                    continue
                 wcs = self.app.data_collection[data_label].coords
                 new_x[these], new_y[these] = wcs.world_to_pixel(orig_world_x[these]*u.deg,
                                                                 orig_world_y[these]*u.deg)

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -144,8 +144,12 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
                 if not np.any(these):
                     continue
                 wcs = self.app.data_collection[data_label].coords
-                new_x[these], new_y[these] = wcs.world_to_pixel(orig_world_x[these]*u.deg,
-                                                                orig_world_y[these]*u.deg)
+                try:
+                    new_x[these], new_y[these] = wcs.world_to_pixel(orig_world_x[these]*u.deg,
+                                                                    orig_world_y[these]*u.deg)
+                except ValueError:
+                    new_x, new_y = [], []
+                    break
 
         viewer_mark.x, viewer_mark.y = new_x, new_y
 

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -83,7 +83,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
         # account for image rotation due to a change in reference data
         self.hub.subscribe(self, ChangeRefDataMessage,
-                           handler=lambda msg: self._recompute_mark_positions(msg.viewer))
+                           handler=lambda msg: self._recompute_mark_positions(msg.viewer,
+                                                                              new_wcs=msg.data.coords))  # noqa
 
         # enable/disable mark based on whether parent data entry is in viewer
         self.hub.subscribe(self, AddDataMessage,
@@ -102,7 +103,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
     def _on_viewer_added(self, msg):
         self._create_viewer_callbacks(self.app.get_viewer_by_id(msg.viewer_id))
 
-    def _recompute_mark_positions(self, viewer):
+    def _recompute_mark_positions(self, viewer, new_wcs=None):
         if self.table is None or self.table._qtable is None:
             return
 
@@ -119,9 +120,16 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         orig_world_y = self.table._qtable['world'][:, 1][in_viewer]
 
         if self.app._link_type == 'wcs':
-            new_wcs = viewer.state.reference_data.coords
-            new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg,
-                                                  orig_world_y*u.deg)
+            if new_wcs is None:
+                new_wcs = viewer.state.reference_data.coords
+            try:
+                new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg,
+                                                      orig_world_y*u.deg)
+            except ValueError:
+                # can temporarily fail with "ValueError: Number of world inputs (2) does not match
+                # expected (1)", in which case we'll temporarily clear markers and should resolve
+                # itself on the next message
+                new_x, new_y = [], []
         else:
             # then pixel linked, so we need to convert based on the WCS of the individual data
             # layers on which each mark was first created

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -3,7 +3,8 @@ from astropy import units as u
 from traitlets import Bool, observe
 
 from jdaviz.core.events import (ViewerAddedMessage, ChangeRefDataMessage,
-                                AddDataMessage, RemoveDataMessage)
+                                AddDataMessage, RemoveDataMessage,
+                                MarkersPluginUpdate)
 from jdaviz.core.marks import MarkersMark
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import PluginTemplateMixin, ViewerSelectMixin, TableMixin
@@ -225,6 +226,8 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             x, y = row_info['axes_x'], row_info['axes_y']
             self._get_mark(viewer).append_xy(getattr(x, 'value', x), getattr(y, 'value', y))
 
+            self.hub.broadcast(MarkersPluginUpdate(table_length=len(self.table), sender=self))
+
     def clear_table(self):
         """
         Clear all entries/markers from the current table.
@@ -232,3 +235,5 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
         super().clear_table()
         for mark in self.marks.values():
             mark.clear()
+
+        self.hub.broadcast(MarkersPluginUpdate(table_length=0, sender=self))

--- a/jdaviz/configs/default/plugins/markers/markers.py
+++ b/jdaviz/configs/default/plugins/markers/markers.py
@@ -54,7 +54,7 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
             headers = ['pixel', 'pixel:unreliable',
                        'world', 'world:unreliable',
                        'value', 'value:unit', 'value:unreliable',
-                       'viewer', 'link_type', 'reference_data']
+                       'viewer']
 
         elif self.config == 'specviz':
             headers = ['spectral_axis', 'spectral_axis:unit',
@@ -95,13 +95,28 @@ class Markers(PluginTemplateMixin, ViewerSelectMixin, TableMixin):
 
     def _on_refdata_change(self, msg):
         viewer_mark = self._get_mark(msg.viewer)
-        # we act from the previous state instead of the original since the original WCS may have
-        # been deleted.  If this causes a buildup in errors, we could first try to access the
-        # original or cache its WCS in the table so we always have access.
-        prev_x, prev_y = viewer_mark.x, viewer_mark.y
-        prev_wcs = msg.old.coords
-        new_wcs = msg.data.coords
-        new_x, new_y = new_wcs.world_to_pixel(prev_wcs.pixel_to_world(prev_x*u.pix, prev_y*u.pix))
+
+        # TODO: when a data layer is unloaded from the viewer, the marks need to be hidden
+        # and re-shown when added back to the viewer.  When deleted from the app, should the
+        # rows in the table be cleared?  This will then account for the case where a
+        # mark is added to data without WCS that is dropped when changing from pixel->WCS linking
+        orig_world_x = self.table._qtable['world'][:, 0]
+        orig_world_y = self.table._qtable['world'][:, 1]
+
+        if self.app._link_type == 'wcs':
+            new_wcs = msg.data.coords
+            new_x, new_y = new_wcs.world_to_pixel(orig_world_x*u.deg, orig_world_y*u.deg)
+        else:
+            # need to convert based on the WCS of the individual data layers on which the mark
+            # was created
+            data_labels = self.table._qtable['data_label']
+            new_x, new_y = np.zeros_like(orig_world_x), np.zeros_like(orig_world_y)
+            for data_label in np.unique(data_labels):
+                these = data_labels == data_label
+                wcs = self.app.data_collection[data_label].coords
+                new_x[these], new_y[these] = wcs.world_to_pixel(orig_world_x[these]*u.deg,
+                                                                orig_world_y[these]*u.deg)
+
         viewer_mark.x, viewer_mark.y = new_x, new_y
 
     def _get_mark(self, viewer):

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -581,6 +581,11 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
 
         refdata, iref = get_reference_image_data(app)
 
+    # set internal tracking of link_type before changing reference data for anything that is
+    # subscribed to a change in reference data
+    app._link_type = link_type
+    app._wcs_use_affine = wcs_use_affine
+
     if link_type == 'pixels' and old_link_type == 'wcs':
         # if changing from WCS to pixel linking, set bottom image data
         # layer as reference data in all viewers:
@@ -654,9 +659,6 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
 
         app.hub.broadcast(SnackbarMessage(
             'Images successfully relinked', color='success', timeout=8000, sender=app))
-
-    app._link_type = link_type
-    app._wcs_use_affine = wcs_use_affine
 
     for viewer in app._viewer_store.values():
         wcs_linked = link_type == 'wcs'

--- a/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
+++ b/jdaviz/configs/imviz/plugins/coords_info/coords_info.py
@@ -64,7 +64,7 @@ class CoordsInfo(TemplateMixin, DatasetSelectMixin):
                 viewer_refs.append(viewer.reference_id)
 
         self.dataset._manual_options = ['auto', 'none']
-        self.dataset.filters = ['layer_in_viewers']
+        self.dataset.filters = ['layer_in_viewers', 'is_not_wcs_only']
         if self.app.config == 'imviz':
             # filter out scatter-plot entries (from add_markers API, for example)
             self.dataset.add_filter('is_image')

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -16,7 +16,8 @@ from jdaviz.configs.imviz.wcs_utils import (
     get_compass_info, _get_rotated_nddata_from_label
 )
 from jdaviz.core.events import (
-    LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage,
+    LinkUpdatedMessage, ExitBatchLoadMessage, ChangeRefDataMessage,
+    AstrowidgetMarkersChangedMessage, MarkersPluginUpdate,
     SnackbarMessage
 )
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
@@ -60,7 +61,8 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     wcs_use_affine = Bool(True).tag(sync=True)
     wcs_linking_available = Bool(False).tag(sync=True)
 
-    need_clear_markers = Bool(False).tag(sync=True)
+    need_clear_astrowidget_markers = Bool(False).tag(sync=True)
+    plugin_markers_exist = Bool(False).tag(sync=True)
     linking_in_progress = Bool(False).tag(sync=True)
     need_clear_subsets = Bool(False).tag(sync=True)
 
@@ -113,8 +115,11 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
         self.hub.subscribe(self, ExitBatchLoadMessage,
                            handler=self._on_new_app_data)
 
-        self.hub.subscribe(self, MarkersChangedMessage,
-                           handler=self._on_markers_changed)
+        self.hub.subscribe(self, AstrowidgetMarkersChangedMessage,
+                           handler=self._on_astrowidget_markers_changed)
+
+        self.hub.subscribe(self, MarkersPluginUpdate,
+                           handler=self._on_markers_plugin_update)
 
         self.hub.subscribe(self, ChangeRefDataMessage,
                            handler=self._on_refdata_change)
@@ -174,8 +179,11 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
         self._link_image_data()
         self._check_if_data_with_wcs_exists()
 
-    def _on_markers_changed(self, msg):
-        self.need_clear_markers = msg.has_markers
+    def _on_astrowidget_markers_changed(self, msg):
+        self.need_clear_astrowidget_markers = msg.has_markers
+
+    def _on_markers_plugin_update(self, msg):
+        self.plugin_markers_exist = msg.table_length > 0
 
     @observe('link_type_selected', 'wcs_use_fallback', 'wcs_use_affine')
     def _update_link(self, msg={}):
@@ -201,7 +209,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
 
         self.linking_in_progress = True
 
-        if self.need_clear_markers:
+        if self.need_clear_astrowidget_markers:
             setattr(self, msg.get('name'), msg.get('old'))
             self.linking_in_progress = False
             raise ValueError(f"cannot change linking with markers present (value reverted to "
@@ -245,7 +253,7 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
     def vue_delete_subsets(self, *args):
         self.delete_subsets()
 
-    def vue_reset_markers(self, *args):
+    def vue_reset_astrowidget_markers(self, *args):
         for viewer in self.app._viewer_store.values():
             viewer.reset_markers()
 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -137,7 +137,7 @@
         </div>
 
       </div>
-      <div v-if="need_clear_markers"
+      <div v-if="need_clear_astrowidget_markers"
             class="text-center"
             style="grid-area: 1/1; 
                    z-index:2;
@@ -148,7 +148,7 @@
          <v-card color="transparent" elevation=0 >
            <v-card-text width="100%">
              <div class="white--text">
-               Markers must be cleared before re-linking
+               Astrowidget markers must be cleared before re-linking
              </div>
            </v-card-text>
 
@@ -158,7 +158,12 @@
              </v-row>
            </v-card-actions>
          </v-card>
-      </div>      
+      </div>
+
+      <v-alert v-if="plugin_markers_exist" type='warning' style="margin-left: -12px; margin-right: -12px">
+        Marker positions may not be pixel-perfect when changing link options.
+      </v-alert>
+  
       <div v-if="linking_in_progress"
            class="text-center"
            style="grid-area: 1/1; 

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -7,32 +7,58 @@
 
     <div style="display: grid"> <!-- overlay container -->
       <div style="grid-area: 1/1">
-        <div v-if="!wcs_linking_available">
-          <v-alert type='warning' style="margin-left: -12px; margin-right: -12px">
-              Please add at least one data with valid WCS to link by WCS
-          </v-alert>
+        <v-alert v-if="!wcs_linking_available" type='warning' style="margin-left: -12px; margin-right: -12px">
+            Please add at least one data with valid WCS to link by WCS
+        </v-alert>
+
+        <div v-if="need_clear_astrowidget_markers"
+              class="text-center"
+              style="grid-area: 1/1; 
+                     z-index:2;
+                     margin-left: -24px;
+                     margin-right: -24px;
+                     padding-top: 60px;
+                     background-color: rgb(0 0 0 / 80%)">
+           <v-card color="transparent" elevation=0 >
+             <v-card-text width="100%">
+               <div class="white--text">
+                 Astrowidget markers must be cleared before re-linking
+               </div>
+             </v-card-text>
+
+             <v-card-actions>
+               <v-row justify="end">
+                 <v-btn tile small color="accent" class="mr-4" @click="reset_markers" >Clear Markers</v-btn>
+               </v-row>
+             </v-card-actions>
+           </v-card>
         </div>
+
+        <v-alert v-if="plugin_markers_exist" type='warning' style="margin-left: -12px; margin-right: -12px">
+          Marker positions may not be pixel-perfect when changing link options.
+        </v-alert>
+
         <v-row>
-        <v-radio-group
-          label="Link type"
-          hint="Type of linking to be done."
-          v-model="link_type_selected"
-          @change="delete_subsets($event)"
-          :disabled="!wcs_linking_available"
-          persistent-hint
-          row>
-          <v-radio
-            v-for="item in link_type_items"
-            :key="item.label"
-            :label="item.label"
-            :value="item.label"
-          ></v-radio>
-        </v-radio-group>
-        <div v-if="need_clear_subsets">
-          <v-alert type='warning' style="margin-left: -12px; margin-right: -12px">
-              Existing subsets will be deleted on changing link type.
-          </v-alert>
-        </div>
+          <v-radio-group
+            label="Link type"
+            hint="Type of linking to be done."
+            v-model="link_type_selected"
+            @change="delete_subsets($event)"
+            :disabled="!wcs_linking_available"
+            persistent-hint
+            row>
+            <v-radio
+              v-for="item in link_type_items"
+              :key="item.label"
+              :label="item.label"
+              :value="item.label"
+            ></v-radio>
+          </v-radio-group>
+          <div v-if="need_clear_subsets">
+            <v-alert type='warning' style="margin-left: -12px; margin-right: -12px">
+                Existing subsets will be deleted on changing link type.
+            </v-alert>
+          </div>
         </v-row>
 
         <v-row>
@@ -135,35 +161,8 @@
                   <v-btn color="primary" color="accent" text :disabled="rotation_angle===''" @click="create_new_orientation_from_data">Add orientation</v-btn>
                 </v-row>
         </div>
-
-      </div>
-      <div v-if="need_clear_astrowidget_markers"
-            class="text-center"
-            style="grid-area: 1/1; 
-                   z-index:2;
-                   margin-left: -24px;
-                   margin-right: -24px;
-                   padding-top: 60px;
-                   background-color: rgb(0 0 0 / 80%)">
-         <v-card color="transparent" elevation=0 >
-           <v-card-text width="100%">
-             <div class="white--text">
-               Astrowidget markers must be cleared before re-linking
-             </div>
-           </v-card-text>
-
-           <v-card-actions>
-             <v-row justify="end">
-               <v-btn tile small color="accent" class="mr-4" @click="reset_markers" >Clear Markers</v-btn>
-             </v-row>
-           </v-card-actions>
-         </v-card>
       </div>
 
-      <v-alert v-if="plugin_markers_exist" type='warning' style="margin-left: -12px; margin-right: -12px">
-        Marker positions may not be pixel-perfect when changing link options.
-      </v-alert>
-  
       <div v-if="linking_in_progress"
            class="text-center"
            style="grid-area: 1/1; 

--- a/jdaviz/configs/imviz/tests/test_links_control.py
+++ b/jdaviz/configs/imviz/tests/test_links_control.py
@@ -16,16 +16,16 @@ class TestLinksControl(BaseImviz_WCS_WCS):
         assert lc_plugin.wcs_use_affine is True
 
         # adding markers should disable changing linking from both UI and API
-        assert lc_plugin.need_clear_markers is False
+        assert lc_plugin.need_clear_astrowidget_markers is False
         tbl = Table({'x': (0, 0), 'y': (0, 1)})
         self.viewer.add_markers(tbl, marker_name='xy_markers')
 
-        assert lc_plugin.need_clear_markers is True
+        assert lc_plugin.need_clear_astrowidget_markers is True
         with pytest.raises(ValueError, match="cannot change linking"):
             lc_plugin.link_type.selected = 'WCS'
         assert lc_plugin.link_type.selected == 'Pixels'
 
         lc_plugin.vue_reset_markers()
 
-        assert lc_plugin.need_clear_markers is False
+        assert lc_plugin.need_clear_astrowidget_markers is False
         lc_plugin.link_type.selected = 'WCS'

--- a/jdaviz/configs/imviz/tests/test_links_control.py
+++ b/jdaviz/configs/imviz/tests/test_links_control.py
@@ -25,7 +25,7 @@ class TestLinksControl(BaseImviz_WCS_WCS):
             lc_plugin.link_type.selected = 'WCS'
         assert lc_plugin.link_type.selected == 'Pixels'
 
-        lc_plugin.vue_reset_markers()
+        lc_plugin.vue_reset_astrowidget_markers()
 
         assert lc_plugin.need_clear_astrowidget_markers is False
         lc_plugin.link_type.selected = 'WCS'

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -10,7 +10,7 @@ from glue.config import colormaps
 from glue.core import Data
 
 from jdaviz.configs.imviz.helper import get_top_layer_index
-from jdaviz.core.events import SnackbarMessage, MarkersChangedMessage
+from jdaviz.core.events import SnackbarMessage, AstrowidgetMarkersChangedMessage
 from jdaviz.core.helpers import data_has_valid_wcs
 
 __all__ = ['AstrowidgetsImageViewerMixin']
@@ -500,7 +500,7 @@ class AstrowidgetsImageViewerMixin:
 
             self._marktags.add(marker_name)
 
-            self.session.hub.broadcast(MarkersChangedMessage(True, sender=self))
+            self.session.hub.broadcast(AstrowidgetMarkersChangedMessage(True, sender=self))
 
     def remove_markers(self, marker_name=None):
         """Remove some but not all of the markers by name used when
@@ -535,7 +535,8 @@ class AstrowidgetsImageViewerMixin:
         self.session.application.data_collection.remove(data)
         self._marktags.remove(marker_name)
 
-        self.session.hub.broadcast(MarkersChangedMessage(len(self._marktags) > 0, sender=self))
+        self.session.hub.broadcast(AstrowidgetMarkersChangedMessage(len(self._marktags) > 0,
+                                                                    sender=self))
 
     def reset_markers(self):
         """Delete all markers."""

--- a/jdaviz/core/events.py
+++ b/jdaviz/core/events.py
@@ -7,7 +7,8 @@ __all__ = ['NewViewerMessage', 'ViewerAddedMessage', 'ViewerRemovedMessage', 'Lo
            'SliceSelectSliceMessage',
            'SliceToolStateMessage',
            'TableClickMessage', 'LinkUpdatedMessage', 'ExitBatchLoadMessage',
-           'MarkersChangedMessage', 'CanvasRotationChangedMessage',
+           'AstrowidgetMarkersChangedMessage', 'MarkersPluginUpdate',
+           'CanvasRotationChangedMessage',
            'GlobalDisplayUnitChanged', 'ChangeRefDataMessage']
 
 
@@ -352,8 +353,8 @@ class ExitBatchLoadMessage(Message):
         super().__init__(*args, **kwargs)
 
 
-class MarkersChangedMessage(Message):
-    '''Message generated when markers are added/removed from an image viewer'''
+class AstrowidgetMarkersChangedMessage(Message):
+    '''Message generated when markers are added/removed from an image viewer via astrowidgets API'''
     def __init__(self, has_markers, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._has_markers = has_markers
@@ -361,6 +362,13 @@ class MarkersChangedMessage(Message):
     @property
     def has_markers(self):
         return self._has_markers
+
+
+class MarkersPluginUpdate(Message):
+    '''Message when the length of the markers plugin table changes'''
+    def __init__(self, table_length, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.table_length = table_length
 
 
 class CanvasRotationChangedMessage(Message):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request repositions markers in the markers plugin table when there is a change in reference data, by making all marks "stick" to their position on the "active" data layer at the time each mark was created.  This also means that marks are hidden if the data on which they were created is unloaded from the viewer (and re-appear if they're reloaded).


change of link-type:

https://github.com/bmorris3/jdaviz/assets/877591/55c1bb66-adbc-4443-923e-d3c0ccd3d0c0


change in rotation:


https://github.com/bmorris3/jdaviz/assets/877591/6609ba57-4c49-4539-93dc-1d57b7b772f5




There will need to be a follow-up effort to handle what to do with marks created on layers _without_ WCS that are then dropped when changing to pixel linking (and similarly for marks corresponding to data-layers that are later removed from the viewer and/or app).


**Original implementation (for context with discussion below)**:

https://github.com/bmorris3/jdaviz/assets/877591/eb049364-98f8-4a77-be0d-e0ddad4a62dd



