### PR TITLE
Make WCS-only layers not visible on refdata change

### DIFF
--- a/jdaviz/configs/imviz/wcs_utils.py
+++ b/jdaviz/configs/imviz/wcs_utils.py
@@ -438,11 +438,10 @@ def _prepare_rotated_nddata(real_image_shape, wcs, rotation_angle, refdata_shape
         image_shape=real_image_shape
     )
 
-    # create a fake NDData (we use arange so data boundaries show up in Imviz
-    # if it ever is accidentally exposed) with the rotated GWCS:
-    sequential_data = np.arange(
-        np.prod(refdata_shape), dtype=np.int8
-    ).reshape(refdata_shape)
+    # create a fake NDData with the rotated GWCS:
+    sequential_data = np.nan * np.empty(
+        refdata_shape, dtype=np.int8
+    )
 
     ndd = NDData(
         data=sequential_data,


### PR DESCRIPTION
### Description

When a WCS-only layer is added to the data collection, it is briefly visible to the user before it is made invisible. Since the data values in the WCS-only layer are an array of ascending integers, the data are recognizable and confusing for users who shouldn't have to know what that layer is. Here's before: 

https://github.com/bmorris3/jdaviz/assets/3497584/57ed6fda-cf28-4321-8ec9-1f85de5c7f13

This PR changes the values of the WCS-only layer to all NaNs to make the layer invisible and avoid visual confusion. Here's after:

https://github.com/bmorris3/jdaviz/assets/3497584/6a47878b-1118-4302-aab7-014296ecafcf
