### PR TITLE
show sky coordinates in subset plugin when wcs linked

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1088,7 +1088,6 @@ class Application(VuetifyTemplate, HubListener):
                                                      get_sky_regions=include_sky_region)
 
             elif isinstance(subset.subset_state, RoiSubsetState):
-
                 subset_region = self._get_roi_subset_definition(subset.subset_state,
                                                                 to_sky=include_sky_region)
 

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -1021,6 +1021,17 @@ class Application(VuetifyTemplate, HubListener):
 
         return regions
 
+    def _get_wcs_from_subset(self, subset_state):
+        """ Usually WCS is subset.parent.coords, except special cubeviz case."""
+
+        if self.config == 'cubeviz':
+            parent_data = subset_state.attributes[0].parent
+            wcs = parent_data.meta.get("_orig_spatial_wcs", None)
+        else:
+            wcs = subset_state.xatt.parent.coords
+
+        return wcs
+
     def get_subsets(self, subset_name=None, spectral_only=False,
                     spatial_only=False, object_only=False,
                     simplify_spectral=True, use_display_units=False,
@@ -1209,11 +1220,7 @@ class Application(VuetifyTemplate, HubListener):
 
         wcs = None
         if to_sky:
-            if self.config == 'cubeviz':
-                parent_data = subset_state.attributes[0].parent
-                wcs = parent_data.meta.get("_orig_spatial_wcs", None)
-            else:
-                wcs = subset_state.xatt.parent.coords  # imviz, try getting WCS from subset data
+            wcs = self._get_wcs_from_subset(subset_state)
 
         # if no spatial wcs on subset, we have to skip computing sky region for this subset
         # but want to do so without raising an error (since many subsets could be requested)

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -90,16 +90,18 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         self.subset_states = []
         self.spectral_display_unit = None
 
-        self.display_sky_coordinates = (self.app._link_type == 'wcs' and not self.multiselect)
+        link_type = getattr(self.app, '_link_type', None)
+        self.display_sky_coordinates = (link_type == 'wcs' and not self.multiselect)
 
     def _on_link_update(self, *args):
-	"""When linking is changed pixels<>wcs, change display units of the
-	   subset plugin from pixel (for pixel linking) to sky (for WCS linking).
-	   If there is an active selection in the subset plugin, push this change
-	   to the UI upon link change by calling _get_subset_definition, which
-	   will re-determine how to display subset information."""
+        """When linking is changed pixels<>wcs, change display units of the
+        subset plugin from pixel (for pixel linking) to sky (for WCS linking).
+        If there is an active selection in the subset plugin, push this change
+        to the UI upon link change by calling _get_subset_definition, which
+        will re-determine how to display subset information."""
 
-		self.display_sky_coordinates = (self.app._link_type == 'wcs')
+        link_type = getattr(self.app, '_link_type', None)
+        self.display_sky_coordinates = (link_type == 'wcs')
 
         if self.subset_selected != self.subset_select.default_text:
             self._get_subset_definition(*args)
@@ -162,10 +164,11 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
             self.is_centerable = True
             return
 
+        include_sky_region = bool(self.display_sky_coordinates)
         subset_information = self.app.get_subsets(self.subset_selected,
                                                   simplify_spectral=False,
                                                   use_display_units=True,
-                                                  include_sky_region=True)
+                                                  include_sky_region=include_sky_region)
 
         _around_decimals = 6  # Avoid 30 degrees from coming back as 29.999999999999996
         if not subset_information:

--- a/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/subset_plugin.py
@@ -90,17 +90,16 @@ class SubsetPlugin(PluginTemplateMixin, DatasetSelectMixin):
         self.subset_states = []
         self.spectral_display_unit = None
 
-        link_type = getattr(self.app, '_link_type', None)
-        self.display_sky_coordinates = (link_type == 'wcs' and not self.multiselect)
+        self.display_sky_coordinates = (self.app._link_type == 'wcs' and not self.multiselect)
 
     def _on_link_update(self, *args):
-        """When linking is changed pixels<>wcs, change display units of the
-           subset plugin from pixel (for pixel linking) to sky (for wcs linking).
-           If there is an active selection in the subset plugin, push this change
-           to the UI upon link change by calling _get_subset_definition, which
-           will re-determine how to display subset information."""
+	"""When linking is changed pixels<>wcs, change display units of the
+	   subset plugin from pixel (for pixel linking) to sky (for WCS linking).
+	   If there is an active selection in the subset plugin, push this change
+	   to the UI upon link change by calling _get_subset_definition, which
+	   will re-determine how to display subset information."""
 
-        self.display_sky_coordinates = (self.app._link_type == 'wcs')
+		self.display_sky_coordinates = (self.app._link_type == 'wcs')
 
         if self.subset_selected != self.subset_select.default_text:
             self._get_subset_definition(*args)

--- a/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/tests/test_subset_plugin.py
@@ -1,7 +1,13 @@
 import warnings
 import pytest
 
-from glue.core.roi import XRangeROI
+import numpy as np
+from astropy.nddata import NDData
+from glue.core.roi import EllipticalROI, CircularROI, CircularAnnulusROI, RectangularROI, XRangeROI
+from numpy.testing import assert_allclose
+
+from jdaviz.configs.default.plugins.subset_plugin import utils
+from jdaviz.core.region_translators import regions2roi
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -25,3 +31,140 @@ def test_subset_definition_with_composite_subset(cubeviz_helper, spectrum1d_cube
         warnings.simplefilter('ignore')
         cubeviz_helper.load_data(spectrum1d_cube)
     cubeviz_helper.app.get_tray_item_from_name('g-subset-plugin')
+
+
+circle_subset_info = {'xc': {'pixel_name': 'X Center (pixels)', 'wcs_name':
+                             'RA Center (degrees)', 'initial_value': 5,
+                             'final_value': 6},
+                      'yc': {'pixel_name': 'Y Center (pixels)', 'wcs_name':
+                             'Dec Center (degrees)', 'initial_value': 5,
+                             'final_value': 6},
+                      'radius': {'pixel_name': 'Radius (pixels)', 'wcs_name':
+                                 'Radius (degrees)', 'initial_value': 2,
+                                 'final_value': 3}}
+elliptical_subset_info = {'xc': {'pixel_name': 'X Center (pixels)', 'wcs_name':
+                                 'RA Center (degrees)', 'initial_value': 5.,
+                                 'final_value': 6.},
+                          'yc': {'pixel_name': 'Y Center (pixels)', 'wcs_name':
+                                 'Dec Center (degrees)', 'initial_value': 5.,
+                                 'final_value': 6.},
+                          'radius_x': {'pixel_name': 'X Radius (pixels)', 'wcs_name':
+                                       'RA Radius (degrees)', 'initial_value': 2.,
+                                       'final_value': 3.},
+                          'radius_y': {'pixel_name': 'Y Radius (pixels)', 'wcs_name':
+                                       'Dec Radius (degrees)', 'initial_value': 5.,
+                                       'final_value': 6.},
+                          'theta': {'pixel_name': 'Angle', 'wcs_name':
+                                    'Angle', 'initial_value': 0.,
+                                    'final_value': 45.}}
+circ_annulus_subset_info = {'xc': {'pixel_name': 'X Center (pixels)', 'wcs_name':
+                                   'RA Center (degrees)', 'initial_value': 5.,
+                                   'final_value': 6.},
+                            'yc': {'pixel_name': 'Y Center (pixels)', 'wcs_name':
+                                   'Dec Center (degrees)', 'initial_value': 5.,
+                                   'final_value': 6.},
+                            'inner_radius': {'pixel_name': 'Inner Radius (pixels)', 'wcs_name':
+                                             'Inner Radius (degrees)', 'initial_value': 2.,
+                                             'final_value': 3.},
+                            'outer_radius': {'pixel_name': 'Outer Radius (pixels)', 'wcs_name':
+                                             'Outer Radius (degrees)', 'initial_value': 5.,
+                                             'final_value': 6.}}
+rectangular_subset_info = {'xmin': {'pixel_name': 'Xmin (pixels)', 'wcs_name':
+                                    'RA min (degrees)', 'initial_value': 5.,
+                                    'final_value': 6.},
+                           'xmax': {'pixel_name': 'Xmax (pixels)', 'wcs_name':
+                                    'RA max (degrees)', 'initial_value': 6.,
+                                    'final_value': 7.},
+                           'ymin': {'pixel_name': 'Ymin (pixels)', 'wcs_name':
+                                    'Dec min (degrees)', 'initial_value': 2.,
+                                    'final_value': 3.},
+                           'ymax': {'pixel_name': 'Ymax (pixels)', 'wcs_name':
+                                    'Dec max (degrees)', 'initial_value': 5.,
+                                    'final_value': 6.}}
+
+
+@pytest.mark.parametrize("roi_class, subset_info", [(CircularROI, circle_subset_info),
+                                                    (EllipticalROI, elliptical_subset_info),
+                                                    (CircularAnnulusROI, circ_annulus_subset_info),
+                                                    (RectangularROI, rectangular_subset_info)])
+def test_circle_recenter_linking(roi_class, subset_info, imviz_helper, image_2d_wcs):
+
+    arr = np.ones((10, 10))
+    ndd = NDData(arr, wcs=image_2d_wcs)
+    imviz_helper.load_data(ndd, data_label='dataset1')
+    imviz_helper.load_data(ndd, data_label='dataset2')
+
+    # apply subset
+    roi_params = {key: subset_info[key]['initial_value'] for key in subset_info}
+    imviz_helper.app.get_viewer('imviz-0').apply_roi(roi_class(**roi_params))
+
+    # get plugin and check that attribute tracking link type is set properly
+    plugin = imviz_helper.plugins['Subset Tools']._obj
+    assert not plugin.display_sky_coordinates
+
+    # get initial subset definitions from ROI applied
+    subset_defs = plugin.subset_definitions
+
+    # check that the subset definitions, which control what is displayed in the UI, are correct
+    for i, attr in enumerate(subset_info):
+        assert subset_defs[0][i+1]['name'] == subset_info[attr]['pixel_name']
+        assert subset_defs[0][i+1]['value'] == subset_info[attr]['initial_value']
+
+    # get original subset location as a sky region for use later
+    original_subs = imviz_helper.app.get_subsets(include_sky_region=True)
+    original_sky_region = original_subs['Subset 1'][0]['sky_region']
+
+    # move subset (subset state is what is modified in UI)
+    for attr in subset_info:
+        plugin._set_value_in_subset_definition(0, subset_info[attr]['pixel_name'],
+                                               attr, subset_info[attr]['final_value'])
+
+    # update subset to apply these changes
+    plugin.vue_update_subset()
+    subset_defs = plugin.subset_definitions
+
+    # and check that it is changed after vue_update_subset runs
+    for i, attr in enumerate(subset_info):
+        assert subset_defs[0][i+1]['name'] == subset_info[attr]['pixel_name']
+        assert subset_defs[0][i+1]['value'] == subset_info[attr]['final_value']
+
+    # get updated subset location as a sky region, we need this later
+    updated_sky_region = imviz_helper.app.get_subsets(include_sky_region=True)
+    updated_sky_region = updated_sky_region['Subset 1'][0]['sky_region']
+
+    # remove subsets and change link type to wcs
+    dc = imviz_helper.app.data_collection
+    dc.remove_subset_group(dc.subset_groups[0])
+    imviz_helper.link_data(link_type='wcs')
+    assert plugin.display_sky_coordinates  # linking change should trigger change to True
+
+    # apply original subset. transform sky coord of original subset to new pixels
+    # using wcs of orientation layer (won't be the same as original pixels when pix linked)
+    img_wcs = imviz_helper.app.data_collection['Default orientation'].coords
+    new_pix_region = original_sky_region.to_pixel(img_wcs)
+    new_roi = regions2roi(new_pix_region)
+    imviz_helper.app.get_viewer('imviz-0').apply_roi(new_roi)
+
+    # get subset definitions again, which should now be in sky coordinates
+    subset_defs = plugin.subset_definitions
+
+    # check that the subset definitions, which control what is displayed in the UI,
+    # are correct and match original sky region generated when we were first pix linked
+    true_values_orig = utils._sky_region_to_subset_def(original_sky_region)
+
+    for i, attr in enumerate(subset_info):
+        assert subset_defs[0][i+1]['name'] == subset_info[attr]['wcs_name']
+        assert_allclose(subset_defs[0][i+1]['value'], true_values_orig[i]['value'])
+
+    true_values_final = utils._sky_region_to_subset_def(updated_sky_region)
+
+    for i, attr in enumerate(subset_info):
+        plugin._set_value_in_subset_definition(0, subset_info[attr]['wcs_name'],
+                                               attr, true_values_final[i]['value'])
+    # update subset
+    plugin.vue_update_subset()
+
+    subset_defs = plugin.subset_definitions
+    for i, attr in enumerate(subset_info):
+        assert subset_defs[0][i+1]['name'] == subset_info[attr]['wcs_name']
+        assert_allclose(subset_defs[0][i+1]['value'], true_values_final[i]['value'])

--- a/jdaviz/configs/default/plugins/subset_plugin/utils.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/utils.py
@@ -1,0 +1,170 @@
+"""
+Utility functions for subset plugin these don't belong in
+glue.core.region_translators, as they deal with conversions that
+only happen within this plugin (e.g between region/'subset defintion')
+"""
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from regions import CircleAnnulusSkyRegion, CircleSkyRegion, EllipseSkyRegion, RectangleSkyRegion
+
+from jdaviz.core.region_translators import regions2roi
+
+__all__ = []
+
+
+def _subset_def_to_region(subset_type, sub, val='value', name='name'):
+    """Subset definitions are carried through the plugin in a list of dictionaries,
+    one entry for each ROI attribute of that subset along with its value,
+    its previous value, and the name to display for that attribute in the UI.
+    (see _unpack_get_subsets_for_ui for how these are constructed).
+
+    This function takes one of those dictionary lists describing a subset,
+    and converts it to a Regions object.
+
+    Parameters
+    ----------
+    subset_type : str
+        Name of ROI class (CircularROI/TrueCircularROI, EllipticalROI,
+        CircularAnnulusROI, or RectangularROI)
+    sub : list of dict
+        List of dictionaries defining the subset, with one dict for each
+        subset attribute (see _unpack_get_subsets_for_ui for how these
+        are defined)
+    val : str
+        Key to get subset attribute (e.g radius, xc, yc) value. Will
+        normally be 'value' or 'orig' within plugin to get the new and
+        previous values of the attribute, respectivley.
+    name : str
+        Key to get subset attribute name. Will normally be 'name'.
+
+    Returns
+    -------
+    reg : `SkyRegion` or `PixelRegion`
+        A SkyRegion or PixelRegion object (depending on what
+        `region_type` is) of the subset that the dictionary `sub`
+        represents.
+    """
+
+    if "CircularROI" in subset_type:  # TrueCircular or Circular
+        reg = CircleSkyRegion(center=SkyCoord(*[x[val] for x in sub if 'Center' in x[name]]*u.deg),
+                              radius=[x[val] for x in sub if 'Radius' in x[name]][0]*u.deg)
+    elif subset_type == "EllipticalROI":
+        rads = [x[val] for x in sub if 'Radius' in x[name]]
+        reg = EllipseSkyRegion(SkyCoord(*[x[val] for x in sub if 'Center' in x[name]]*u.deg),
+                               width=2.*rads[0]*u.deg,
+                               height=2.*rads[1]*u.deg,
+                               angle=[x[val] for x in sub if 'Angle' in x[name]][0]*u.deg)
+
+    elif subset_type == "CircularAnnulusROI":
+        rads = [x[val] for x in sub if 'Radius' in x['name']]
+        reg = CircleAnnulusSkyRegion(SkyCoord(*[x[val] for x in sub if 'Center' in x[name]]*u.deg),
+                                     inner_radius=rads[0]*u.deg,
+                                     outer_radius=rads[1]*u.deg)
+
+    elif subset_type == "RectangularROI":
+        xmin, ymin = [x[val] for x in sub if 'min' in x[name]]
+        xmax, ymax = [x[val] for x in sub if 'max' in x[name]]
+        angle = [x[val] for x in sub if 'Angle' in x[name]][0]
+        width = xmax - xmin
+        height = ymax - ymin
+        center = ((xmin+xmax) / 2, (ymin+ymax) / 2)
+        reg = RectangleSkyRegion(center=SkyCoord(*center*u.deg),
+                                 width=width*u.deg,
+                                 height=height*u.deg,
+                                 angle=angle*u.deg)
+    return reg
+
+
+def _sky_region_to_subset_def(sky_region, _around_decimals=6):
+    """Generates a 'subset_definition' list of dictionaries from a
+       `regions.SkyRegion`object.
+
+       Parameters
+       ----------
+        sky_region : `regions.SkyRegion`
+            Name of ROI class (CircularROI/TrueCircularROI, EllipticalROI,
+            CircularAnnulusROI, or RectangularROI)
+        _around_decimals : str
+            Rounding for 'theta', if present.
+
+       Returns
+       -------
+        deff : list of dict
+            List of dictionaries, each sub-dictionary describing a
+            subset attribute."""
+
+    if isinstance(sky_region, CircleSkyRegion):
+        x = sky_region.center.ra.deg
+        y = sky_region.center.dec.deg
+        r = sky_region.radius.deg
+        deff = [{"name": 'RA Center (degrees)', "att": "xc", "value": x, "orig": x},
+                {"name": 'Dec Center (degrees)', "att": "yc", "value": y, "orig": y},
+                {"name": 'Radius (degrees)', "att": "radius", "value": r, "orig": r}]
+
+    if isinstance(sky_region, EllipseSkyRegion):
+        xc = sky_region.center.ra.deg
+        yc = sky_region.center.dec.deg
+        rx = sky_region.width.to(u.deg).value / 2.
+        ry = sky_region.height.to(u.deg).value / 2.
+        ang = (sky_region.angle).to(u.deg).value
+        theta = np.around(ang, decimals=_around_decimals)
+        deff = [{"name": "RA Center (degrees)", "att": "xc", "value": xc, "orig": xc},
+                {"name": "Dec Center (degrees)", "att": "yc", "value": yc, "orig": yc},
+                {"name": "RA Radius (degrees)", "att": "radius_x", "value": rx, "orig": rx},
+                {"name": "Dec Radius (degrees)", "att": "radius_y", "value": ry, "orig": ry},
+                {"name": "Angle", "att": "theta", "value": theta, "orig": theta}]
+
+    if isinstance(sky_region, CircleAnnulusSkyRegion):
+        xc = sky_region.center.ra.deg
+        yc = sky_region.center.dec.deg
+        inner_r = sky_region.inner_radius.to(u.deg).value
+        outer_r = sky_region.outer_radius.to(u.deg).value
+        deff = [{"name": "RA Center (degrees)", "att": "xc", "value": xc, "orig": xc},
+                {"name": "Dec Center (degrees)", "att": "yc", "value": yc, "orig": yc},
+                {"name": "Inner Radius (degrees)", "att": "inner_radius",
+                 "value": inner_r, "orig": inner_r},
+                {"name": "Outer Radius (degrees)", "att": "outer_radius",
+                 "value": outer_r, "orig": outer_r}]
+
+    if isinstance(sky_region, RectangleSkyRegion):
+        deff = []
+        mins_maxs = {'xmin': sky_region.center.ra.deg - ((sky_region.width).to(u.deg).value / 2.),
+                     'xmax': sky_region.center.ra.deg + ((sky_region.width).to(u.deg).value / 2.),
+                     'ymin': sky_region.center.dec.deg - ((sky_region.height).to(u.deg).value / 2.),
+                     'ymax': sky_region.center.dec.deg + ((sky_region.height).to(u.deg).value / 2.)}
+        for att in ("Xmin", "Xmax", "Ymin", "Ymax"):
+            val = mins_maxs[att.lower()]
+            name = att.replace('X', 'RA ').replace('Y', 'Dec ')
+            deff.append({"name": f"{name} (degrees)", "att": att.lower(),
+                         "value": val, "orig": val})
+        theta = (sky_region.angle).to(u.deg).value
+        deff.append({"name": "Angle", "att": "theta", "value": theta, "orig": theta})
+
+    return deff
+
+
+def _get_pixregion_params_in_dict(region):
+    """Given a Region, returns a dictionary with the attribute names
+    of the corresponding ROI type (i.e CirclePixelRegion and CircularROI).
+
+   This makes use of `jdaviz.core.region_translators.regions2roi`, but instead
+   of returning an ROI object it returns a dictionary of parameters that
+   would be used to create that same ROI object. This involves changing some
+   keys and deleting some, which is why that `regions2roi` can't be
+   called directly.
+   """
+
+    roi = regions2roi(region)
+    region_dict = roi.__dict__.copy()
+
+    if 'center' in region_dict.keys():
+        region_dict['xc'] = region_dict['center'].x
+        region_dict['yc'] = region_dict['center'].y
+        del region_dict['center']
+
+    region_dict.pop('meta', None)
+    region_dict.pop('visual', None)
+
+    return region_dict

--- a/jdaviz/configs/default/plugins/subset_plugin/utils.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/utils.py
@@ -89,8 +89,8 @@ def _sky_region_to_subset_def(sky_region, _around_decimals=6):
     _around_decimals : str
         Rounding for 'theta', if present.
 
-     Returns
-     -------
+    Returns
+    -------
     deff : list of dict
         List of dictionaries, each sub-dictionary describing a
         subset attribute."""

--- a/jdaviz/configs/default/plugins/subset_plugin/utils.py
+++ b/jdaviz/configs/default/plugins/subset_plugin/utils.py
@@ -78,22 +78,22 @@ def _subset_def_to_region(subset_type, sub, val='value', name='name'):
 
 
 def _sky_region_to_subset_def(sky_region, _around_decimals=6):
-    """Generates a 'subset_definition' list of dictionaries from a
-       `regions.SkyRegion`object.
+    """ Generates a 'subset_definition' list of dictionaries from a
+    `regions.SkyRegion`object.
 
-       Parameters
-       ----------
-        sky_region : `regions.SkyRegion`
-            Name of ROI class (CircularROI/TrueCircularROI, EllipticalROI,
-            CircularAnnulusROI, or RectangularROI)
-        _around_decimals : str
-            Rounding for 'theta', if present.
+    Parameters
+    ----------
+    sky_region : `regions.SkyRegion`
+        Name of ROI class (CircularROI/TrueCircularROI, EllipticalROI,
+        CircularAnnulusROI, or RectangularROI).
+    _around_decimals : str
+        Rounding for 'theta', if present.
 
-       Returns
-       -------
-        deff : list of dict
-            List of dictionaries, each sub-dictionary describing a
-            subset attribute."""
+     Returns
+     -------
+    deff : list of dict
+        List of dictionaries, each sub-dictionary describing a
+        subset attribute."""
 
     if isinstance(sky_region, CircleSkyRegion):
         x = sky_region.center.ra.deg
@@ -106,9 +106,9 @@ def _sky_region_to_subset_def(sky_region, _around_decimals=6):
     if isinstance(sky_region, EllipseSkyRegion):
         xc = sky_region.center.ra.deg
         yc = sky_region.center.dec.deg
-        rx = sky_region.width.to(u.deg).value / 2.
-        ry = sky_region.height.to(u.deg).value / 2.
-        ang = (sky_region.angle).to(u.deg).value
+        rx = sky_region.width.to_value(u.deg) * 0.5
+        ry = sky_region.height.to_value(u.deg) * 0.5
+        ang = sky_region.angle.to_value(u.deg)
         theta = np.around(ang, decimals=_around_decimals)
         deff = [{"name": "RA Center (degrees)", "att": "xc", "value": xc, "orig": xc},
                 {"name": "Dec Center (degrees)", "att": "yc", "value": yc, "orig": yc},
@@ -119,8 +119,8 @@ def _sky_region_to_subset_def(sky_region, _around_decimals=6):
     if isinstance(sky_region, CircleAnnulusSkyRegion):
         xc = sky_region.center.ra.deg
         yc = sky_region.center.dec.deg
-        inner_r = sky_region.inner_radius.to(u.deg).value
-        outer_r = sky_region.outer_radius.to(u.deg).value
+        inner_r = sky_region.inner_radius.to_value(u.deg)
+        outer_r = sky_region.outer_radius.to_value(u.deg)
         deff = [{"name": "RA Center (degrees)", "att": "xc", "value": xc, "orig": xc},
                 {"name": "Dec Center (degrees)", "att": "yc", "value": yc, "orig": yc},
                 {"name": "Inner Radius (degrees)", "att": "inner_radius",
@@ -139,7 +139,7 @@ def _sky_region_to_subset_def(sky_region, _around_decimals=6):
             name = att.replace('X', 'RA ').replace('Y', 'Dec ')
             deff.append({"name": f"{name} (degrees)", "att": att.lower(),
                          "value": val, "orig": val})
-        theta = (sky_region.angle).to(u.deg).value
+        theta = sky_region.angle.to_value(u.deg)
         deff.append({"name": "Angle", "att": "theta", "value": theta, "orig": theta})
 
     return deff
@@ -147,14 +147,14 @@ def _sky_region_to_subset_def(sky_region, _around_decimals=6):
 
 def _get_pixregion_params_in_dict(region):
     """Given a Region, returns a dictionary with the attribute names
-    of the corresponding ROI type (i.e CirclePixelRegion and CircularROI).
+    of the corresponding ROI type (i.e., CirclePixelRegion and CircularROI).
 
-   This makes use of `jdaviz.core.region_translators.regions2roi`, but instead
-   of returning an ROI object it returns a dictionary of parameters that
-   would be used to create that same ROI object. This involves changing some
-   keys and deleting some, which is why that `regions2roi` can't be
-   called directly.
-   """
+    This makes use of `jdaviz.core.region_translators.regions2roi`, but instead
+    of returning an ROI object it returns a dictionary of parameters that
+    would be used to create that same ROI object. This involves changing some
+    keys and deleting some, which is why that `regions2roi` can't be
+    called directly.
+    """
 
     roi = regions2roi(region)
     region_dict = roi.__dict__.copy()

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -152,13 +152,13 @@ class TestLoadRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
         # This file actually will load 2 annuli
         regfile = get_pkg_data_filename('data/ds9_annulus_01.reg')
         self.imviz.load_data(regfile)
-        #assert len(self.imviz.app.data_collection) == 2  # Make sure not loaded as data
+        assert len(self.imviz.app.data_collection) == 2  # Make sure not loaded as data
 
-        # subsets = self.imviz.get_interactive_regions()
-        # subset_names = list(subsets.keys())
-        # assert subset_names == ['Subset 1', 'Subset 2']
-        # for n in subset_names:
-        #     assert isinstance(subsets[n], CircleAnnulusPixelRegion)
+        subsets = self.imviz.get_interactive_regions()
+        subset_names = list(subsets.keys())
+        assert subset_names == ['Subset 1', 'Subset 2']
+        for n in subset_names:
+            assert isinstance(subsets[n], CircleAnnulusPixelRegion)
 
     def test_photutils_pixel(self):
         my_aper = CircularAperture((5, 5), r=2)

--- a/jdaviz/configs/imviz/tests/test_regions.py
+++ b/jdaviz/configs/imviz/tests/test_regions.py
@@ -152,13 +152,13 @@ class TestLoadRegions(BaseImviz_WCS_NoWCS, BaseRegionHandler):
         # This file actually will load 2 annuli
         regfile = get_pkg_data_filename('data/ds9_annulus_01.reg')
         self.imviz.load_data(regfile)
-        assert len(self.imviz.app.data_collection) == 2  # Make sure not loaded as data
+        #assert len(self.imviz.app.data_collection) == 2  # Make sure not loaded as data
 
-        subsets = self.imviz.get_interactive_regions()
-        subset_names = list(subsets.keys())
-        assert subset_names == ['Subset 1', 'Subset 2']
-        for n in subset_names:
-            assert isinstance(subsets[n], CircleAnnulusPixelRegion)
+        # subsets = self.imviz.get_interactive_regions()
+        # subset_names = list(subsets.keys())
+        # assert subset_names == ['Subset 1', 'Subset 2']
+        # for n in subset_names:
+        #     assert isinstance(subsets[n], CircleAnnulusPixelRegion)
 
     def test_photutils_pixel(self):
         my_aper = CircularAperture((5, 5), r=2)

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -9,7 +9,7 @@ from photutils.aperture import (ApertureStats, CircularAperture, EllipticalApert
                                 RectangularAperture, EllipticalAnnulus)
 from regions import (CircleAnnulusPixelRegion, CirclePixelRegion, EllipsePixelRegion,
                      RectanglePixelRegion, PixCoord)
-from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI, XRangeROI
+from glue.core.roi import CircularROI, EllipticalROI, RectangularROI
 
 from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import (
     _curve_of_growth, _radial_profile)
@@ -138,7 +138,6 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         # Make sure it also works on a rectangle subset.
         # We also subtract off background from itself here.
-        #self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
         self.imviz.default_viewer.apply_roi(RectangularROI(0, 9, 0, 9))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.aperture_selected = 'Subset 3'
@@ -360,7 +359,6 @@ def test_annulus_background(imviz_helper):
 
     # Draw ellipse on another object
     # EllipsePixelRegion(center=PixCoord(x=20.5, y=20.5), width=41, height=15)
-    #imviz_helper._apply_interactive_region('bqplot:ellipse', (0, 30), (41, 45))
     imviz_helper.default_viewer.apply_roi(EllipticalROI(20.5, 20.5, 41, 15))
 
     # Load annulus (this used to be part of the plugin but no longer)

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -9,6 +9,7 @@ from photutils.aperture import (ApertureStats, CircularAperture, EllipticalApert
                                 RectangularAperture, EllipticalAnnulus)
 from regions import (CircleAnnulusPixelRegion, CirclePixelRegion, EllipsePixelRegion,
                      RectanglePixelRegion, PixCoord)
+from glue.core.roi import CircularROI, CircularAnnulusROI, EllipticalROI, RectangularROI, XRangeROI
 
 from jdaviz.configs.imviz.plugins.aper_phot_simple.aper_phot_simple import (
     _curve_of_growth, _radial_profile)
@@ -137,7 +138,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
 
         # Make sure it also works on a rectangle subset.
         # We also subtract off background from itself here.
-        self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
+        #self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
+        self.imviz.default_viewer.apply_roi(RectangularROI(0, 9, 0, 9))
         phot_plugin.dataset_selected = 'has_wcs_1[SCI,1]'
         phot_plugin.aperture_selected = 'Subset 3'
         phot_plugin.background_selected = 'Subset 3'
@@ -339,7 +341,7 @@ def test_annulus_background(imviz_helper):
 
     # Mark an object of interest
     # CirclePixelRegion(center=PixCoord(x=150, y=25), radius=7)
-    imviz_helper._apply_interactive_region('bqplot:truecircle', (143, 18), (157, 32))
+    imviz_helper.default_viewer.apply_roi(CircularROI(150, 25, 7))
 
     # Load annulus (this used to be part of the plugin but no longer)
     annulus_1 = CircleAnnulusPixelRegion(
@@ -357,8 +359,9 @@ def test_annulus_background(imviz_helper):
     assert_allclose(phot_plugin.background_value, 5.745596129482831)  # Changed
 
     # Draw ellipse on another object
-    # EllipsePixelRegion(center=PixCoord(x=20.5, y=37.5), width=41, height=15)
-    imviz_helper._apply_interactive_region('bqplot:ellipse', (0, 30), (41, 45))
+    # EllipsePixelRegion(center=PixCoord(x=20.5, y=20.5), width=41, height=15)
+    #imviz_helper._apply_interactive_region('bqplot:ellipse', (0, 30), (41, 45))
+    imviz_helper.default_viewer.apply_roi(EllipticalROI(20.5, 20.5, 41, 15))
 
     # Load annulus (this used to be part of the plugin but no longer)
     annulus_2 = CircleAnnulusPixelRegion(
@@ -390,10 +393,10 @@ def test_annulus_background(imviz_helper):
     # Edit the annulus and make sure background updates
     subset_plugin = imviz_helper.plugins["Subset Tools"]._obj
     subset_plugin.subset_selected = "Subset 4"
-    subset_plugin._set_value_in_subset_definition(0, "X Center", "value", 25.5)
-    subset_plugin._set_value_in_subset_definition(0, "Y Center", "value", 42.5)
-    subset_plugin._set_value_in_subset_definition(0, "Inner radius", "value", 40)
-    subset_plugin._set_value_in_subset_definition(0, "Outer radius", "value", 45)
+    subset_plugin._set_value_in_subset_definition(0, "X Center (pixels)", "value", 25.5)
+    subset_plugin._set_value_in_subset_definition(0, "Y Center (pixels)", "value", 42.5)
+    subset_plugin._set_value_in_subset_definition(0, "Inner Radius (pixels)", "value", 40)
+    subset_plugin._set_value_in_subset_definition(0, "Outer Radius (pixels)", "value", 45)
     subset_plugin.vue_update_subset()
     assert_allclose(phot_plugin.background_value, 4.89189)
 

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -358,8 +358,8 @@ def test_annulus_background(imviz_helper):
     assert_allclose(phot_plugin.background_value, 5.745596129482831)  # Changed
 
     # Draw ellipse on another object
-    # EllipsePixelRegion(center=PixCoord(x=20.5, y=20.5), width=41, height=15)
-    imviz_helper.default_viewer.apply_roi(EllipticalROI(20.5, 20.5, 41, 15))
+    # EllipsePixelRegion(center=PixCoord(x=20.5, y=37.5), width=41, height=15)
+    imviz_helper.default_viewer.apply_roi(EllipticalROI(20.5, 37.5, 41, 15))
 
     # Load annulus (this used to be part of the plugin but no longer)
     annulus_2 = CircleAnnulusPixelRegion(

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -1,3 +1,5 @@
+from astropy.coordinates import SkyCoord
+import astropy.units as u
 from numpy.testing import assert_allclose
 from regions import PixCoord, CirclePixelRegion
 
@@ -20,13 +22,13 @@ class TestImvizSpatialSubsetCentroidPixelLinked(BaseImviz_WCS_GWCS):
             plg._obj.vue_recenter_subset()
 
             # Calculate and move to centroid.
-            for key in ("X Center", "Y Center"):
+            for key in ("X Center (pixels)", "Y Center (pixels)"):
                 assert plg._obj._get_value_from_subset_definition(0, key, "value") == -1
                 assert plg._obj._get_value_from_subset_definition(0, key, "orig") == -1
 
             # Radius will not be touched.
             for key in ("value", "orig"):
-                assert plg._obj._get_value_from_subset_definition(0, "Radius", key) == 3
+                assert plg._obj._get_value_from_subset_definition(0, "Radius (pixels)", key) == 3
 
         assert plg._obj.get_center() == (-1, -1)
 
@@ -47,10 +49,12 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         data = self.imviz.app.data_collection[plg._obj.dataset_selected]
         # Pixel value is now w.r.t. fake WCS layer, not the selected data.
         for key in ("value", "orig"):
-            x = plg._obj._get_value_from_subset_definition(0, "X Center", key)
-            y = plg._obj._get_value_from_subset_definition(0, "Y Center", key)
-            data_xy = self.viewer._get_real_xy(data, x, y)[:2]
-            assert_allclose(data_xy, -1)
+            # subset definition is now in sky coordinates. get RA and Dec and convert back to pixel
+            # to compare with expected recentered position.
+            ra = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key) * u.deg
+            dec = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key) * u.deg
+            x, y = SkyCoord(ra, dec).to_pixel(self.wcs_1)
+            assert_allclose((x, y), -1)
 
         # GWCS does not extrapolate and this Subset is out of bounds,
         # so will get NaNs and enter the exception handling logic.
@@ -58,15 +62,23 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         plg._obj.set_center((2.6836, 1.6332), update=True)  # Move the Subset back first.
         plg._obj.vue_recenter_subset()
         for key in ("value", "orig"):
-            x = plg._obj._get_value_from_subset_definition(0, "X Center", key)
-            y = plg._obj._get_value_from_subset_definition(0, "Y Center", key)
-            assert_allclose((x, y), (2.6836, 1.6332))
+            ra = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key)
+            dec = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key)
+
+            # make sure what is in subset_definitions matches what is returned by get_subsets
+            subsets = self.imviz.app.get_subsets(include_sky_region=True)
+            subsets_sky = subsets['Subset 1'][0]['sky_region']
+            assert_allclose((ra, dec), (subsets_sky.center.ra.deg, subsets_sky.center.dec.deg))
+            subsets_pix = subsets['Subset 1'][0]['region']
+            assert_allclose((subsets_pix.center.x, subsets_pix.center.y), (2.6836, 1.6332))
 
         # The functionality for set_center has changed so that the subset state itself
         # is updated but that change is not propagated to subset_definitions or the UI until
         # vue_update_subset is called.
         plg._obj.set_center((2, 2), update=False)
         for key in ("value", "orig"):
-            x = plg._obj._get_value_from_subset_definition(0, "X Center", key)
-            y = plg._obj._get_value_from_subset_definition(0, "Y Center", key)
-            assert_allclose((x, y), (2.6836, 1.6332))
+            x = plg._obj._get_value_from_subset_definition(0, "RA Center (degrees)", key)
+            y = plg._obj._get_value_from_subset_definition(0, "Dec Center (degrees)", key)
+            # here 'ra' and 'dec' should remain unchanged from when they were defined, since
+            # vue_update_subset hasn't run
+            assert_allclose((x, y), (ra, dec))

--- a/jdaviz/configs/imviz/tests/test_subset_centroid.py
+++ b/jdaviz/configs/imviz/tests/test_subset_centroid.py
@@ -46,7 +46,7 @@ class TestImvizSpatialSubsetCentroidWCSLinked(BaseImviz_WCS_GWCS):
         plg._obj.subset_selected = 'Subset 1'
         plg._obj.dataset_selected = 'fits_wcs[DATA]'
         plg._obj.vue_recenter_subset()
-        data = self.imviz.app.data_collection[plg._obj.dataset_selected]
+
         # Pixel value is now w.r.t. fake WCS layer, not the selected data.
         for key in ("value", "orig"):
             # subset definition is now in sky coordinates. get RA and Dec and convert back to pixel

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -82,26 +82,26 @@ def test_region_from_subset_3d(cubeviz_helper):
     assert subset_plugin.is_centerable
     assert subset_plugin.get_center() == (2.25, 1.55)
     for key in ("orig", "value"):
-        assert subset_plugin._get_value_from_subset_definition(0, "Xmin", key) == 1
-        assert subset_plugin._get_value_from_subset_definition(0, "Xmax", key) == 3.5
-        assert subset_plugin._get_value_from_subset_definition(0, "Ymin", key) == -0.2
-        assert subset_plugin._get_value_from_subset_definition(0, "Ymax", key) == 3.3
+        assert subset_plugin._get_value_from_subset_definition(0, "Xmin (pixels)", key) == 1
+        assert subset_plugin._get_value_from_subset_definition(0, "Xmax (pixels)", key) == 3.5
+        assert subset_plugin._get_value_from_subset_definition(0, "Ymin (pixels)", key) == -0.2
+        assert subset_plugin._get_value_from_subset_definition(0, "Ymax (pixels)", key) == 3.3
         assert subset_plugin._get_value_from_subset_definition(0, "Angle", key) == 0
 
     # Mimic user changing something in Subset Tool GUI.
-    subset_plugin._set_value_in_subset_definition(0, "Xmin", "value", 2)
-    subset_plugin._set_value_in_subset_definition(0, "Ymin", "value", 0)
+    subset_plugin._set_value_in_subset_definition(0, "Xmin (pixels)", "value", 2)
+    subset_plugin._set_value_in_subset_definition(0, "Ymin (pixels)", "value", 0)
     subset_plugin._set_value_in_subset_definition(0, "Angle", "value", 45)  # ccw deg
     # "orig" is unchanged until user clicks Update button.
-    assert subset_plugin._get_value_from_subset_definition(0, "Xmin", "orig") == 1
-    assert subset_plugin._get_value_from_subset_definition(0, "Ymin", "orig") == -0.2
+    assert subset_plugin._get_value_from_subset_definition(0, "Xmin (pixels)", "orig") == 1
+    assert subset_plugin._get_value_from_subset_definition(0, "Ymin (pixels)", "orig") == -0.2
     assert subset_plugin._get_value_from_subset_definition(0, "Angle", "orig") == 0
     subset_plugin.vue_update_subset()
     for key in ("orig", "value"):
-        assert subset_plugin._get_value_from_subset_definition(0, "Xmin", key) == 2
-        assert subset_plugin._get_value_from_subset_definition(0, "Xmax", key) == 3.5
-        assert subset_plugin._get_value_from_subset_definition(0, "Ymin", key) == 0
-        assert subset_plugin._get_value_from_subset_definition(0, "Ymax", key) == 3.3
+        assert subset_plugin._get_value_from_subset_definition(0, "Xmin (pixels)", key) == 2
+        assert subset_plugin._get_value_from_subset_definition(0, "Xmax (pixels)", key) == 3.5
+        assert subset_plugin._get_value_from_subset_definition(0, "Ymin (pixels)", key) == 0
+        assert subset_plugin._get_value_from_subset_definition(0, "Ymax (pixels)", key) == 3.3
         assert subset_plugin._get_value_from_subset_definition(0, "Angle", key) == 45
 
     subsets = cubeviz_helper.app.get_subsets()
@@ -132,9 +132,9 @@ def test_region_from_subset_3d(cubeviz_helper):
     assert subset_plugin.subset_types == ["CircularROI"]
     assert subset_plugin.is_centerable
     for key in ("orig", "value"):
-        assert subset_plugin._get_value_from_subset_definition(0, "X Center", key) == 3
-        assert subset_plugin._get_value_from_subset_definition(0, "Y Center", key) == 4
-        assert subset_plugin._get_value_from_subset_definition(0, "Radius", key) == 2.4
+        assert subset_plugin._get_value_from_subset_definition(0, "X Center (pixels)", key) == 3
+        assert subset_plugin._get_value_from_subset_definition(0, "Y Center (pixels)", key) == 4
+        assert subset_plugin._get_value_from_subset_definition(0, "Radius (pixels)", key) == 2.4
 
     # Circular Annulus Subset
     flux_viewer = cubeviz_helper.app.get_viewer("flux-viewer")
@@ -147,10 +147,10 @@ def test_region_from_subset_3d(cubeviz_helper):
     assert subset_plugin.subset_selected == "Subset 3"
     assert subset_plugin.subset_types == ["CircularAnnulusROI"]
     for key in ("orig", "value"):
-        assert subset_plugin._get_value_from_subset_definition(0, "X Center", key) == 5
-        assert subset_plugin._get_value_from_subset_definition(0, "Y Center", key) == 6
-        assert subset_plugin._get_value_from_subset_definition(0, "Inner radius", key) == 2
-        assert subset_plugin._get_value_from_subset_definition(0, "Outer radius", key) == 4
+        assert subset_plugin._get_value_from_subset_definition(0, "X Center (pixels)", key) == 5
+        assert subset_plugin._get_value_from_subset_definition(0, "Y Center (pixels)", key) == 6
+        assert subset_plugin._get_value_from_subset_definition(0, "Inner Radius (pixels)", key) == 2
+        assert subset_plugin._get_value_from_subset_definition(0, "Outer Radius (pixels)", key) == 4
 
 
 def test_region_from_subset_profile(cubeviz_helper, spectral_cube_wcs):

--- a/jdaviz/tests/test_subsets.py
+++ b/jdaviz/tests/test_subsets.py
@@ -43,10 +43,10 @@ def test_region_from_subset_2d(cubeviz_helper):
     assert subset_plugin.subset_types == ["EllipticalROI"]
     assert subset_plugin.is_centerable
     for key in ("orig", "value"):
-        assert subset_plugin._get_value_from_subset_definition(0, "X Center", key) == 1
-        assert subset_plugin._get_value_from_subset_definition(0, "Y Center", key) == 3.5
-        assert subset_plugin._get_value_from_subset_definition(0, "X Radius", key) == 1.2
-        assert subset_plugin._get_value_from_subset_definition(0, "Y Radius", key) == 3.3
+        assert subset_plugin._get_value_from_subset_definition(0, "X Center (pixels)", key) == 1
+        assert subset_plugin._get_value_from_subset_definition(0, "Y Center (pixels)", key) == 3.5
+        assert subset_plugin._get_value_from_subset_definition(0, "X Radius (pixels)", key) == 1.2
+        assert subset_plugin._get_value_from_subset_definition(0, "Y Radius (pixels)", key) == 3.3
         assert subset_plugin._get_value_from_subset_definition(0, "Angle", key) == 0
 
     # Recenter GUI should not be exposed, but API call would raise exception.


### PR DESCRIPTION
This PR changes the behavior of the subset plugin to reflect link type (pixel or wcs). If wcs linked, subset attributes (e.g center, radius) will be displayed in the plugin in sky coordinates. If pixel linked, they will be displayed in pixels. 

I added a subset_plugin.utils module to handle the translation between what is referred to in the plugin as 'subset_definition', a list of dictionaries each containing information about each subset attribute and regions/ROI/etc. This keeps most of the translations out of the actual plugin, and accessible by tests. I can think of some ways this could be improved in the future (defining a 'SubsetDefinition' class in the plugin, so that the structure of the dictionary doesn't have to be repeated so much), but in another PR.

Additionally, as referenced in the discussion below, we may want to remove the check if old==new upon update because this adds in another unnecessary pixel <> sky. I tried doing that by simply removing the check, and allowing it to change upon clicking 'update' even if the values didn't change, and I noticed that it wandered a bit while I did this presumably due to rounding and pixel>sky conversion internally. I do think this could be done smarter, but I'm not sure I want to change that here (I tried the comparison before conversion, and other errors came up, so I need to dig into this more).

Finally, the comment about rectangle corners not staying fixed upon changing one boundary is unfortunately how it's supposed to work. The rectangular subset xmin/xmax/ymin/ymax are the bounds before rotation, so the center can change. It is unintuitive but re defining it in terms of center/width/height will have to happen down the line. 
