### PR TITLE
Ensure subset highlights are not visible on WCS-only layers

### DIFF
--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -146,7 +146,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         self.linking_in_progress = True
         self.wcs_use_fallback = msg.wcs_use_fallback
         self.wcs_use_affine = msg.wcs_use_affine
-        self.orientation.only_wcs_layers = self.link_type_selected == 'WCS'
+        self.orientation.only_wcs_layers = self.link_type.selected == 'WCS'
         self.orientation._on_layers_changed()
 
     def _link_image_data(self):
@@ -368,6 +368,18 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
             elif not len(viewer.data()):
                 self.link_type_selected = link_type_msg_to_trait['pixels']
 
+            # we never want to highlight subsets of pixels within WCS-only layers,
+            # so if this layer is an ImageSubsetLayerState on a WCS-only layer,
+            # ensure that it is never visible:
+            for layer in viewer.state.layers:
+                if (
+                    hasattr(layer.layer, 'label') and
+                    layer.layer.label.startswith("Subset") and
+                    hasattr(layer.layer.data, 'meta') and
+                    layer.layer.data.meta.get("_WCS_ONLY", False)
+                ):
+                    layer.visible = False
+
     @property
     def ref_data(self):
         return self.app.get_viewer_by_id(self.viewer.selected).state.reference_data
@@ -415,7 +427,7 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
         """
         if label not in self.orientation.choices:
             degn = self._get_wcs_angles()[-3]
-            self.add_orientation(rotation_angle=180-degn, east_left=False,
+            self.add_orientation(rotation_angle=180 - degn, east_left=False,
                                  label=label, set_on_create=set_on_create)
         elif set_on_create:
             self.orientation.selected = label

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -375,7 +375,6 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
                 if (
                     hasattr(layer.layer, 'label') and
                     layer.layer.label.startswith("Subset") and
-                    hasattr(layer.layer.data, 'meta') and
                     layer.layer.data.meta.get("_WCS_ONLY", False)
                 ):
                     layer.visible = False

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1294,9 +1294,9 @@ class LayerSelect(SelectPluginComponent):
                 layer for viewer in viewers
                 for layer in getattr(viewer, 'layers', [])
                 # don't include WCS-only layers unless asked:
-                if (
-                    not hasattr(layer.layer, 'meta') or
-                    (not layer.layer.meta.get('_WCS_ONLY', False))
+                if not hasattr(layer.layer, 'meta') or (
+                    hasattr(layer.layer, 'meta') and
+                    not layer.layer.meta.get('_WCS_ONLY', False)
                 )
             ]
         else:
@@ -1304,7 +1304,10 @@ class LayerSelect(SelectPluginComponent):
                 layer for viewer in viewers
                 for layer in getattr(viewer, 'layers', [])
                 # only include WCS-only layers:
-                if not hasattr(layer.layer, 'meta') or layer.layer.meta.get('_WCS_ONLY', False)
+                if (
+                    hasattr(layer.layer, 'meta') and
+                    layer.layer.meta.get('_WCS_ONLY', False)
+                )
             ]
         # remove duplicates - NOTE: by doing this, any color-mismatch between layers with the
         # same name in different viewers will be randomly assigned within plot_options

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1295,7 +1295,6 @@ class LayerSelect(SelectPluginComponent):
                 for layer in getattr(viewer, 'layers', [])
                 # don't include WCS-only layers unless asked:
                 if not hasattr(layer.layer, 'meta') or (
-                    hasattr(layer.layer, 'meta') and
                     not layer.layer.meta.get('_WCS_ONLY', False)
                 )
             ]


### PR DESCRIPTION
### Description

Clare found a case where the subset highlighting becomes visible on WCS-only data layers [🐱](https://jira.stsci.edu/browse/JDAT-3976). To reproduce on the image rotation branch: load example data into Imviz, link by WCS, create a subset, add a new orientation option, and the subset highlighting will be on the reference data layer as well as the image data layers.

This PR ensures that the subset is not highlighted on WCS-only layers by forcing `visible=False` on `ImageSubsetLayerState`s on WCS-only layers on reference data change.