### PR TITLE
Fixes for WCS-only layers across multiple image viewers

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -559,7 +559,6 @@ class Application(VuetifyTemplate, HubListener):
             viewer.zoom(
                 float(fov_sky_final / fov_sky_init)
             )
-            # viewer.center_on(sky_cen)
 
         # only re-center the viewer if all data layers have WCS:
         has_wcs_per_data = [data_has_valid_wcs(d) for d in viewer.data()]

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2298,7 +2298,7 @@ class Application(VuetifyTemplate, HubListener):
                 # adopt "linked_by_wcs" from the first (assuming all are the same)
                 # NOTE: deleting the default viewer is forbidden both by API and UI, but if
                 # for some reason that was the case here, linked_by_wcs will default to False
-                linked_by_wcs = list(self._viewer_store.values())[0].state.linked_by_wcs  # noqa
+                linked_by_wcs = self._jdaviz_helper.default_viewer.state.linked_by_wcs
             viewer.state.linked_by_wcs = linked_by_wcs
 
         if linked_by_wcs:

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2286,7 +2286,7 @@ class Application(VuetifyTemplate, HubListener):
             msg.cls, data=msg.data, show=False)
         viewer.figure_widget.layout.height = '100%'
 
-        linked_by_wcs = self._link_type.lower() == 'wcs'
+        linked_by_wcs = self._link_type == 'wcs'
 
         if hasattr(viewer.state, 'linked_by_wcs'):
             orientation_plugin = self._jdaviz_helper.plugins.get('Orientation', None)

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -559,6 +559,7 @@ class Application(VuetifyTemplate, HubListener):
             viewer.zoom(
                 float(fov_sky_final / fov_sky_init)
             )
+            # viewer.center_on(sky_cen)
 
         # only re-center the viewer if all data layers have WCS:
         has_wcs_per_data = [data_has_valid_wcs(d) for d in viewer.data()]
@@ -2317,7 +2318,7 @@ class Application(VuetifyTemplate, HubListener):
         )
 
         ref_data = self._jdaviz_helper.default_viewer._obj.state.reference_data
-        new_viewer_item['reference_data_label'] = ref_data.label
+        new_viewer_item['reference_data_label'] = getattr(ref_data, 'label', None)
 
         new_stack_item = self._create_stack_item(
             container='gl-stack',

--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2298,7 +2298,7 @@ class Application(VuetifyTemplate, HubListener):
                 # adopt "linked_by_wcs" from the first (assuming all are the same)
                 # NOTE: deleting the default viewer is forbidden both by API and UI, but if
                 # for some reason that was the case here, linked_by_wcs will default to False
-                linked_by_wcs = self._jdaviz_helper.default_viewer.state.linked_by_wcs
+                linked_by_wcs = self._jdaviz_helper.default_viewer._obj.state.linked_by_wcs
             viewer.state.linked_by_wcs = linked_by_wcs
 
         if linked_by_wcs:

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -424,8 +424,14 @@ def get_top_layer_index(viewer):
     This is because when blinked, first layer might not be top visible layer.
 
     """
-    return [i for i, lyr in enumerate(viewer.layers)
-            if lyr.visible and layer_is_image_data(lyr.layer)][-1]
+    visible_image_layers = [
+        i for i, lyr in enumerate(viewer.layers)
+        if lyr.visible and layer_is_image_data(lyr.layer)
+    ]
+
+    if len(visible_image_layers):
+        return visible_image_layers[-1]
+    return None
 
 
 def get_reference_image_data(app, viewer_id=None):

--- a/jdaviz/configs/imviz/plugins/orientation/orientation.py
+++ b/jdaviz/configs/imviz/plugins/orientation/orientation.py
@@ -433,7 +433,9 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
 
     @property
     def ref_data(self):
-        return self.app.get_viewer_by_id(self.viewer.selected).state.reference_data
+        if hasattr(self, 'viewer'):
+            return self.app.get_viewer_by_id(self.viewer.selected).state.reference_data
+        return None
 
     @property
     def _refdata_change_available(self):
@@ -454,9 +456,10 @@ class Orientation(PluginTemplateMixin, ViewerSelectMixin):
     @observe('viewer_selected')
     def _on_viewer_change(self, msg={}):
         # don't update choices until viewer is available:
-        if hasattr(self, 'viewer'):
+        ref_data = self.ref_data
+        if hasattr(self, 'viewer') and ref_data is not None:
             self.orientation.choices = get_wcs_only_layer_labels(self.app)
-            self.orientation.selected = self.ref_data.label
+            self.orientation.selected = ref_data.label
 
     def create_north_up_east_left(self, label="North-up, East-left", set_on_create=False):
         """

--- a/jdaviz/configs/imviz/plugins/viewers.py
+++ b/jdaviz/configs/imviz/plugins/viewers.py
@@ -133,6 +133,8 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
     def on_limits_change(self, *args):
         try:
             i = get_top_layer_index(self)
+            if i is None:
+                return
         except IndexError:
             if self.compass is not None:
                 self.compass.clear_compass()
@@ -147,7 +149,10 @@ class ImvizImageView(JdavizViewerMixin, BqplotImageView, AstrowidgetsImageViewer
         except IndexError:
             data_label = ''
         else:
-            data_label = self.state.layers[i].layer.label
+            if i is None:
+                data_label = ''
+            else:
+                data_label = self.state.layers[i].layer.label
         return data_label
 
     @property

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -77,6 +77,9 @@ class AstrowidgetsImageViewerMixin:
 
         """
         i_top = get_top_layer_index(self)
+        if i_top is None:
+            return
+
         image = self.layers[i_top].layer
 
         if isinstance(point, SkyCoord):

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -1445,13 +1445,18 @@ class LayerSelect(SelectPluginComponent):
             ]
         # remove duplicates - we'll loop back through all selected viewers to get a list of colors
         # and visibilities later within _layer_to_dict
-        layer_labels = [layer.layer.label for layer in all_layers if self.app.state.layer_icons.get(layer.layer.label)]  # noqa
+        layer_labels = [
+            layer.layer.label for layer in all_layers
+            if self.app.state.layer_icons.get(layer.layer.label) or
+            getattr(self, 'only_wcs_layers', False)
+        ]
         unique_layer_labels = list(set(layer_labels))
-
         layer_items = [self._layer_to_dict(layer_label) for layer_label in unique_layer_labels]
 
         def _sort_by_icon(items_dict):
-            return items_dict['icon']
+            icon = items_dict['icon']
+            return icon if icon is not None else ''
+
         layer_items.sort(key=_sort_by_icon)
 
         self.items = manual_items + layer_items

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -1,8 +1,8 @@
 import os
 import time
 
-import astropy.units as u
 import numpy as np
+from astropy import units as u
 from echo import delay_callback
 from glue.config import viewer_tool
 from glue.core import HubListener

--- a/jdaviz/core/tools.py
+++ b/jdaviz/core/tools.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+import astropy.units as u
 import numpy as np
 from echo import delay_callback
 from glue.config import viewer_tool
@@ -111,7 +112,11 @@ class _MatchedZoomMixin:
                 # viewer rotations:
                 to_fov_sky = viewer._get_fov(wcs=orig_refdata.coords)
 
-                viewer.center_on(sky_cen)
+                viewer_center = viewer._get_center_skycoord(orig_refdata)
+                if sky_cen.separation(viewer_center) > 0.1 * u.arcsec:
+                    # avoid recentering if the viewer is already nearly centered
+                    viewer.center_on(sky_cen)
+
                 viewer.zoom(
                     float(to_fov_sky / orig_fov_sky)
                 )


### PR DESCRIPTION
Cami found a few intertwined bugs in how image rotation is handled when new image viewers are created, and when multiple image viewers are open. This PR fixes them to ensure that:
* when a new viewer is created, the default orientation is selected (by default)
* the orientation options available in the data-menu dropdown should match those available in the orientation plugin dropdown

### Change log entry

- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`? If you want to avoid merge conflicts,
  list the proposed change log here for review and add to `CHANGES.rst` before merge. If no, maintainer
  should add a `no-changelog-entry-needed` label.

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a milestone set? Set this to bugfix milestone if this is a bug fix and needs to be released ASAP; otherwise, set this to the next major release milestone.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
