### PR TITLE
provide warning before clicking in dropdown and disable preset/function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Imviz
 - There is now option for image rotation in Orientation (was Links Control) plugin.
   This feature requires WCS linking. [#2179]
 
-- Add "Random" colormap for visualizing image segmentation maps [#2671]
+- Add "Random" colormap for visualizing image segmentation maps. [#2671]
 
 Mosviz
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Imviz
 - There is now option for image rotation in Orientation (was Links Control) plugin.
   This feature requires WCS linking. [#2179]
 
+- Add "Random" colormap for visualizing image segmentation maps [#2671]
+
 Mosviz
 ^^^^^^
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -29,8 +29,32 @@ from jdaviz.core.tools import ICON_DIR
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 
 from scipy.interpolate import PchipInterpolator
+from photutils.utils import make_random_cmap
 
 __all__ = ['PlotOptions']
+
+
+def _register_random_cmap(
+    cmap_name,
+    bkg_color=[0, 0, 0],
+    bkg_alpha=1,
+    seed=42,
+    ncolors=10_000
+):
+    """
+    Custom random colormap, useful for rendering image
+    segmentation maps. The default background for
+    `label==0` is *transparent*. If the segmentation map
+    contains more than 10,000 labels, adjust the `ncolors`
+    kwarg to ensure uniqueness.
+    """
+    cmap = make_random_cmap(ncolors=ncolors, seed=seed)
+    cmap.colors[0] = bkg_color + [bkg_alpha]
+    cmap.name = cmap_name
+    colormaps.add(cmap_name, cmap)
+
+
+_register_random_cmap('Random', bkg_alpha=1)
 
 
 class SplineStretch:
@@ -1093,3 +1117,13 @@ class PlotOptions(PluginTemplateMixin):
             viewers = [viewers]
 
         return np.all([_is_image_viewer(viewer) for viewer in viewers])
+
+    @observe('image_colormap_value')
+    def _random_cmap_limit_update(self, *args, **kwargs):
+        # if 'Random' colormap is used for visualizing image segmentation,
+        # ensure the stretch limits are the min and max, so all label colors
+        # are unique:
+        if self.image_colormap_value != 'Random':
+            return
+
+        self.stretch_preset.value = 100

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -1127,3 +1127,4 @@ class PlotOptions(PluginTemplateMixin):
             return
 
         self.stretch_preset.value = 100
+        self.stretch_function.value = 'linear'

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -439,11 +439,24 @@
             v-model="image_colormap_value"
             label="Colormap"
             dense
-          ></v-select>
-              <v-alert v-if="image_colormap_value == 'Random'" type='warning' style="margin-left: -12px; margin-right: -12px">
-                Note: on selecting the "Random" colormap, the stretch percentile preset
-                is set to min/max and the stretch function is set to linear.
-              </v-alert>
+          >
+            <template slot="item" slot-scope="data">
+              <div class="single-line" style="width: 100%">
+                <j-tooltip v-if="data.item.text === 'Random'" tooltipcontent="Selecting the 'Random' colormap will set the stretch percentile preset
+                to min/max, the stretch function to linear, and prevent manually changing either.">
+                  <span>
+                    {{ data.item.text }}
+                  </span>
+                  <v-icon>
+                    mdi-information-outline
+                  </v-icon>
+                </j-tooltip>
+                <span v-else>
+                  {{ data.item.text }}
+                </span>
+              </div>
+            </template>
+          </v-select>
         </glue-state-sync-wrapper>
         <glue-state-sync-wrapper v-if="image_color_mode_value !== 'Colormaps' || image_color_mode_sync['mixed']" :sync="image_color_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('image_color')">
           <div>
@@ -498,6 +511,7 @@
           v-model="stretch_function_value"
           label="Stretch Function"
           class="no-hint"
+          :disabled="image_colormap_value==='Random'"
         ></v-select>
       </glue-state-sync-wrapper>
 
@@ -509,6 +523,7 @@
           v-model="stretch_preset_value"
           label="Stretch Percentile Preset"
           class="no-hint"
+          :disabled="image_colormap_value==='Random'"
         ></v-select>
       </glue-state-sync-wrapper>
 

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -440,6 +440,10 @@
             label="Colormap"
             dense
           ></v-select>
+              <v-alert v-if="image_colormap_value == 'Random'" type='warning' style="margin-left: -12px; margin-right: -12px">
+                Note: on selecting the "Random" colormap, the stretch percentile preset
+                is set to min/max and the stretch function is set to linear.
+              </v-alert>
         </glue-state-sync-wrapper>
         <glue-state-sync-wrapper v-if="image_color_mode_value !== 'Colormaps' || image_color_mode_sync['mixed']" :sync="image_color_sync" :multiselect="layer_multiselect" @unmix-state="unmix_state('image_color')">
           <div>

--- a/jdaviz/configs/default/plugins/plot_options/plot_options.vue
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.vue
@@ -510,8 +510,10 @@
           :items="stretch_function_sync.choices"
           v-model="stretch_function_value"
           label="Stretch Function"
-          class="no-hint"
           :disabled="image_colormap_value==='Random'"
+          :hint="image_colormap_value==='Random' ? 'Cannot set while colormap is set to Random': null"
+          persistent-hint
+          dense
         ></v-select>
       </glue-state-sync-wrapper>
 
@@ -522,8 +524,10 @@
           :items="stretch_preset_sync.choices"
           v-model="stretch_preset_value"
           label="Stretch Percentile Preset"
-          class="no-hint"
           :disabled="image_colormap_value==='Random'"
+          :hint="image_colormap_value==='Random' ? 'Cannot set while colormap is set to Random': null"
+          persistent-hint
+          dense
         ></v-select>
       </glue-state-sync-wrapper>
 

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -391,3 +391,25 @@ def test_track_mixed_states(imviz_helper):
     assert not po.stretch_function_sync['mixed']
     assert po.stretch_function_value == 'spline'
     assert not po.stretch_params_sync['mixed']
+
+
+def test_segmentation_image(imviz_helper):
+    # Make one circular segment for a hypothetical
+    # image with one source:
+    nx = ny = 100
+    radius = 15
+    x0 = y0 = 50
+
+    segmentation_map = np.zeros((nx, ny))
+    xx, yy = np.meshgrid(np.arange(nx), np.arange(ny))
+    in_circle = np.hypot(xx - x0, yy - y0) < radius
+    segmentation_map[in_circle] = 1
+
+    imviz_helper.load_data(segmentation_map)
+
+    plot_opts = imviz_helper.plugins['Plot Options']
+    plot_opts.image_colormap = 'Random'
+
+    # ensure that stretch preset is listening to the update to the
+    # random colormap so that all colors are uniquely displayed:
+    assert plot_opts.stretch_preset.value == 100

--- a/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/tests/test_plot_options.py
@@ -413,3 +413,4 @@ def test_segmentation_image(imviz_helper):
     # ensure that stretch preset is listening to the update to the
     # random colormap so that all colors are uniquely displayed:
     assert plot_opts.stretch_preset.value == 100
+    assert plot_opts.stretch_function.value == 'linear'

--- a/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
+++ b/jdaviz/configs/imviz/tests/test_astrowidgets_api.py
@@ -182,7 +182,7 @@ class TestCmapStretchCuts(BaseImviz_WCS_NoWCS):
             'Gray', 'Viridis', 'Plasma', 'Inferno', 'Magma', 'Purple-Blue',
             'Yellow-Green-Blue', 'Yellow-Orange-Red', 'Red-Purple', 'Blue-Green',
             'Hot', 'Red-Blue', 'Red-Yellow-Blue', 'Purple-Orange', 'Purple-Green',
-            'Rainbow', 'Seismic',
+            'Random', 'Rainbow', 'Seismic',
             'Reversed: Gray', 'Reversed: Viridis', 'Reversed: Plasma', 'Reversed: Inferno',
             'Reversed: Magma', 'Reversed: Hot', 'Reversed: Rainbow']
 


### PR DESCRIPTION
This PR is a PR to this PR: https://github.com/spacetelescope/jdaviz/pull/2671

This PR moves the warning stating that choosing "Random" as a colormap overrides the values for stretch function and percentile preset from _after_ making the selection to _before_ via a tooltip in the dropdown itself.  This also then disables the inputs for stretch function and percentile preset.


https://github.com/bmorris3/jdaviz/assets/877591/723ef4a6-77b7-4118-9798-04a140f9db9b



Note that this does not technically prevent the user from overriding these values from the API, nor does it result in this warning being raised in advance when setting the colormap to "Random" from the API.

I did not rename "Random" here, but do think that naming it something tied specifically to segmentation maps, and adding that context in the warning itself, would also be useful additions.